### PR TITLE
fix(demo): Add demo to root bundle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,3 +27,5 @@ export {default as TitleBar} from '@ciscospark/react-component-title-bar';
 export {default as TypingAvatar} from '@ciscospark/react-component-typing-avatar';
 export {default as TypingIndicator} from '@ciscospark/react-component-typing-indicator';
 export {default as WidgetMessageMeet} from '@ciscospark/widget-message-meet';
+
+import './demo';


### PR DESCRIPTION
Added the `demo.js` file to the root bundle `index.js` the demo is added to the bundle.