### PR TITLE
docs(widget-message-meet): Fix wrong name in docs

### DIFF
--- a/packages/node_modules/@ciscospark/widget-message-meet/README.md
+++ b/packages/node_modules/@ciscospark/widget-message-meet/README.md
@@ -137,9 +137,9 @@ If you need additional behaviors or need to do additional work before the widget
 <script>
   var widgetEl = document.getElementById('ciscospark-widget');
     // Init a new widget
-  ciscospark.widget(widgetEl).messageMeet({
-    accessToken: 'YOUR_ACCESS_TOKEN'
-    toPersonEmail: 'XXXXX@XXXXXXXXX'
+  ciscospark.widget(widgetEl).messageMeetWidget({
+    accessToken: 'YOUR_ACCESS_TOKEN',
+    toPersonEmail: 'XXXXX@XXXXXXXXX',
     initialActivity: 'message'
   });
 </script>
@@ -204,10 +204,10 @@ If you are using *browser globals*, you can provide a callback parameter that wi
 
 ``` js
 var widgetEl = document.getElementById('ciscospark-widget');
-ciscospark.widget(widgetEl).messageMeet({
-  accessToken: 'YOUR_ACCESS_TOKEN'
-  toPersonEmail: 'XXXXX@XXXXXXXXX'
-  initialActivity: 'message'
+ciscospark.widget(widgetEl).messageMeetWidget({
+  accessToken: 'YOUR_ACCESS_TOKEN',
+  toPersonEmail: 'XXXXX@XXXXXXXXX',
+  initialActivity: 'message',
   startCall: true,
   onEvent: callback
 });


### PR DESCRIPTION
Error in the docs for the browser globals methods.