### PR TITLE
fix: removing workaround for redux-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-router": "^3.0.2",
     "react-tap-event-plugin": "^2.0.1",
     "react-test-renderer": "^15.4.1",
-    "redux-logger": "^2.7.4",
+    "redux-logger": "^2.10.2",
     "redux-mock-store": "^1.2.1",
     "rimraf": "^2.5.4",
     "style-loader": "^0.13.1",

--- a/packages/node_modules/@ciscospark/widget-message-meet/src/store.js
+++ b/packages/node_modules/@ciscospark/widget-message-meet/src/store.js
@@ -13,7 +13,7 @@ const devtools = window.devToolsExtension || (() => (noop) => noop);
 const middlewares = [thunk];
 
 if (process.env.NODE_ENV !== `production`) {
-  const createLogger = require(`redux-logger`).default; // eslint-disable-line global-require
+  const createLogger = require(`redux-logger`); // eslint-disable-line global-require
   const logger = createLogger({
     level: process.env.NODE_ENV === `production` ? `error` : `info`,
     duration: true,


### PR DESCRIPTION
Fix the issue we had a workaround for:
https://github.com/evgenyrodionov/redux-logger/issues/210