### PR TITLE
feat(widget-meet): Render video srcObject instead of url

### DIFF
--- a/packages/node_modules/@ciscospark/react-component-video/src/index.js
+++ b/packages/node_modules/@ciscospark/react-component-video/src/index.js
@@ -3,13 +3,21 @@ import classNames from 'classnames';
 
 import styles from './styles.css';
 
-export default function Video({src, audioMuted}) {
+export default function Video({src, srcObject, audioMuted}) {
   // Need autoPlay to start the video automagically
+
+  function getEl(el) {
+    if (el && srcObject) {
+      el.srcObject = srcObject;
+    }
+  }
+
   return (
     <video
       autoPlay
       className={classNames(styles.video)}
       muted={audioMuted}
+      ref={getEl}
       src={src}
     />
   );
@@ -17,5 +25,6 @@ export default function Video({src, audioMuted}) {
 
 Video.propTypes = {
   audioMuted: PropTypes.bool,
-  src: PropTypes.string.isRequired
+  src: PropTypes.string,
+  srcObject: PropTypes.object
 };

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
@@ -63,8 +63,6 @@ export default function reducer(state = initialState, action) {
       sendingVideo: call.sendingVideo,
       localAudioDirection: call.localAudioDirection,
       localVideoDirection: call.localVideoDirection,
-      remoteMediaStreamUrl: call.remoteMediaStreamUrl,
-      localMediaStreamUrl: call.localMediaStreamUrl,
       remoteMediaStream: call.remoteMediaStream,
       localMediaStream: call.localMediaStream,
       remoteAudioMuted,
@@ -77,7 +75,6 @@ export default function reducer(state = initialState, action) {
     const mediaState = {
       localAudioDirection: call.localAudioDirection,
       localVideoDirection: call.localVideoDirection,
-      localMediaStreamUrl: call.localMediaStreamUrl,
       localMediaStream: call.localMediaStream
     };
     return state.mergeIn([`callState`], mediaState);
@@ -89,7 +86,6 @@ export default function reducer(state = initialState, action) {
       receivingVideo: call.receivingVideo,
       sendingAudio: call.sendingAudio,
       sendingVideo: call.sendingVideo,
-      remoteMediaStreamUrl: call.remoteMediaStreamUrl,
       remoteMediaStream: call.remoteMediaStream
     };
     return state.mergeIn([`callState`], mediaState);
@@ -121,8 +117,6 @@ export default function reducer(state = initialState, action) {
       .set(`call`, call)
       .setIn([`status`, `isConnected`], true)
       .setIn([`status`, `isDialing`], false)
-      .setIn([`callState`, `localMediaStreamUrl`], call.localMediaStreamUrl)
-      .setIn([`callState`, `remoteMediaStreamUrl`], call.remoteMediaStreamUrl)
       .setIn([`callState`, `localMediaStream`], call.localMediaStream)
       .setIn([`callState`, `remoteMediaStream`], call.remoteMediaStream)
       .set(`callStartTime`, Date.parse(call.locus.fullState.lastActive));

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
@@ -65,6 +65,8 @@ export default function reducer(state = initialState, action) {
       localVideoDirection: call.localVideoDirection,
       remoteMediaStreamUrl: call.remoteMediaStreamUrl,
       localMediaStreamUrl: call.localMediaStreamUrl,
+      remoteMediaStream: call.remoteMediaStream,
+      localMediaStream: call.localMediaStream,
       remoteAudioMuted,
       remoteVideoMuted
     };
@@ -75,7 +77,8 @@ export default function reducer(state = initialState, action) {
     const mediaState = {
       localAudioDirection: call.localAudioDirection,
       localVideoDirection: call.localVideoDirection,
-      localMediaStreamUrl: call.localMediaStreamUrl
+      localMediaStreamUrl: call.localMediaStreamUrl,
+      localMediaStream: call.localMediaStream
     };
     return state.mergeIn([`callState`], mediaState);
   }
@@ -86,7 +89,8 @@ export default function reducer(state = initialState, action) {
       receivingVideo: call.receivingVideo,
       sendingAudio: call.sendingAudio,
       sendingVideo: call.sendingVideo,
-      remoteMediaStreamUrl: call.remoteMediaStreamUrl
+      remoteMediaStreamUrl: call.remoteMediaStreamUrl,
+      remoteMediaStream: call.remoteMediaStream
     };
     return state.mergeIn([`callState`], mediaState);
   }
@@ -119,6 +123,8 @@ export default function reducer(state = initialState, action) {
       .setIn([`status`, `isDialing`], false)
       .setIn([`callState`, `localMediaStreamUrl`], call.localMediaStreamUrl)
       .setIn([`callState`, `remoteMediaStreamUrl`], call.remoteMediaStreamUrl)
+      .setIn([`callState`, `localMediaStream`], call.localMediaStream)
+      .setIn([`callState`, `remoteMediaStream`], call.remoteMediaStream)
       .set(`callStartTime`, Date.parse(call.locus.fullState.lastActive));
   }
   case CALL_DISCONNECTED: {

--- a/packages/node_modules/@ciscospark/widget-meet/src/components/call-active/index.js
+++ b/packages/node_modules/@ciscospark/widget-meet/src/components/call-active/index.js
@@ -19,12 +19,12 @@ export default function ActiveCall({
   onStartSendingVideo,
   onStopSendingAudio,
   onStopSendingVideo,
-  localMediaStreamUrl,
-  remoteMediaStreamUrl,
+  localMediaStream,
+  remoteMediaStream,
   toPersonAvatar,
   toPersonName
 }) {
-  const connectedClass = remoteMediaStreamUrl && styles.callConnected;
+  const connectedClass = remoteMediaStream && remoteMediaStream.active && styles.callConnected;
   const {
     sendingAudio,
     sendingVideo
@@ -54,8 +54,8 @@ export default function ActiveCall({
     </div>
   );
 
-  if (remoteMediaStreamUrl && !callState.remoteVideoMuted) {
-    remoteView = <Video src={remoteMediaStreamUrl} />;
+  if (remoteMediaStream && remoteMediaStream.active && !callState.remoteVideoMuted) {
+    remoteView = <Video srcObject={remoteMediaStream} />;
   }
 
   return (
@@ -64,7 +64,7 @@ export default function ActiveCall({
         { remoteView }
       </div>
       {
-        localMediaStreamUrl && sendingVideo &&
+        localMediaStream && localMediaStream.active && sendingVideo &&
         <Draggable
           bounds="parent"
           defaultClassNameDragging={styles.reactDraggableDragging}
@@ -72,12 +72,12 @@ export default function ActiveCall({
           position={localVideoPosition}
         >
           <div className={classNames(styles.localVideo, `local-video`)}>
-            <Video audioMuted src={localMediaStreamUrl} />
+            <Video audioMuted srcObject={localMediaStream} />
           </div>
         </Draggable>
       }
       {
-        localMediaStreamUrl &&
+        localMediaStream && localMediaStream.active &&
         <div className={classNames(styles.callControls, `call-controls`)}>
           <ButtonControls buttons={buttons} showLabels={false} />
         </div>
@@ -88,7 +88,7 @@ export default function ActiveCall({
 
 ActiveCall.propTypes = {
   callState: PropTypes.object,
-  localMediaStreamUrl: PropTypes.string,
+  localMediaStream: PropTypes.object,
   localVideoPosition: PropTypes.object,
   onHangupClick: PropTypes.func.isRequired,
   onLocalVideoDragStop: PropTypes.func,
@@ -96,7 +96,7 @@ ActiveCall.propTypes = {
   onStartSendingVideo: PropTypes.func.isRequired,
   onStopSendingAudio: PropTypes.func.isRequired,
   onStopSendingVideo: PropTypes.func.isRequired,
-  remoteMediaStreamUrl: PropTypes.string,
+  remoteMediaStream: PropTypes.object,
   toPersonAvatar: PropTypes.string,
   toPersonName: PropTypes.string
 };

--- a/packages/node_modules/@ciscospark/widget-meet/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-meet/src/container.js
@@ -218,8 +218,8 @@ export class MeetWidget extends Component {
       } = this;
 
       const callState = media.get(`callState`).toJS();
-      const remoteUrl = media.getIn([`callState`, `remoteMediaStreamUrl`]);
-      const localUrl = media.getIn([`callState`, `localMediaStreamUrl`]);
+      const remoteMediaStream = media.getIn([`callState`, `remoteMediaStream`]);
+      const localMediaStream = media.getIn([`callState`, `localMediaStream`]);
       const isConnected = media.getIn([`status`, `isConnected`]);
       const isDialing = media.getIn([`status`, `isDialing`]);
       const isActiveCall = isDialing || isConnected;
@@ -255,7 +255,7 @@ export class MeetWidget extends Component {
               callState={callState}
               intl={intl}
               isConnected={isConnected}
-              localMediaStreamUrl={localUrl}
+              localMediaStream={localMediaStream}
               localVideoPosition={widgetMeet.get(`localVideoPosition`)}
               onHangupClick={handleHangup}
               onLocalVideoDragStop={handleLocalVideoDragStop}
@@ -263,7 +263,7 @@ export class MeetWidget extends Component {
               onStartSendingVideo={handleStartSendingVideo}
               onStopSendingAudio={handleStopSendingAudio}
               onStopSendingVideo={handleStopSendingVideo}
-              remoteMediaStreamUrl={remoteUrl}
+              remoteMediaStream={remoteMediaStream}
               toPersonAvatar={toPersonAvatar}
               toPersonName={toPersonName}
             />


### PR DESCRIPTION
With `createObjectURL` losing support for media streams, we've created a work around for the react video element to support a `srcObject`