### PR TITLE
feat(redux-module-media): hangup call on disconnect

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
@@ -128,7 +128,7 @@ export function updateWebRTCSupport(supported) {
 
 export function bindCallActions(dispatch, call) {
   call.once(`connected`, () => dispatch(callConnected(call)));
-  call.once(`disconnected`, () => dispatch(callDisconnected(call)));
+  call.once(`disconnected`, () => dispatch(hangupCall(call)));
   call.on(`change:status`, () => dispatch(updateCallState(call)));
   call.on(`change:sendingAudio`, () => dispatch(updateCallState(call)));
   call.on(`change:receivingAudio`, () => dispatch(updateCallState(call)));
@@ -145,9 +145,9 @@ export function bindMediaActions(dispatch, call) {
 
 export function callUser({userIdOrEmail, constraints = {audio: true, video: true}}, spark) {
   return (dispatch) => {
-    dispatch(updateStatus({isDialing: true}));
     spark.phone.createLocalMediaStream(constraints)
       .then((localMediaStream) => {
+        dispatch(updateStatus({isDialing: true}));
         const call = spark.phone.dial(
           userIdOrEmail,
           Object.assign({
@@ -165,6 +165,8 @@ export function callUser({userIdOrEmail, constraints = {audio: true, video: true
 
 export function hangupCall(call) {
   return (dispatch) => {
+    // Don't update call states after hangup
+    call.off();
     call.hangup().then(() => {
       dispatch(callDisconnected());
     });

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
@@ -23,8 +23,8 @@ export const initialState = fromJS({
     call: null
   },
   callState: {
-    sendingAudio: true,
-    sendingVideo: true
+    sendingAudio: false,
+    sendingVideo: false
   },
   webRTC: {
     isCheckingSupport: false,


### PR DESCRIPTION
When an outgoing call was declined by the remote party, the disconnect event would not relinquish the mic and camera. This solves that issue. Will be working on a fix in the sdk as well.