### PR TITLE
fix(react-redux-spark): stop attempting to register on failure

### DIFF
--- a/packages/node_modules/@ciscospark/react-redux-spark/src/component.js
+++ b/packages/node_modules/@ciscospark/react-redux-spark/src/component.js
@@ -74,10 +74,11 @@ class SparkComponent extends Component {
     const {
       authenticated,
       registered,
+      registerError,
       registering
     } = props.spark.get(`status`).toJS();
 
-    if (authenticated && !registered && !registering) {
+    if (authenticated && !registered && !registering && !registerError) {
       props.registerDevice(spark);
     }
   }


### PR DESCRIPTION
If you give a bad token, it will constantly try to register device.