### PR TITLE
feat(widget-base): Allow data api to use browser globals if available

### DIFF
--- a/packages/node_modules/@ciscospark/widget-base/README.md
+++ b/packages/node_modules/@ciscospark/widget-base/README.md
@@ -1,4 +1,4 @@
-# Spark Space Widget _(@ciscospark/widget-base)_
+# Spark Base Widget _(@ciscospark/widget-base)_
 
 > This base React component does the initial React, Spark authentication, and Redux setup for all Spark widgets.
 

--- a/packages/node_modules/@ciscospark/widget-base/src/data-api.js
+++ b/packages/node_modules/@ciscospark/widget-base/src/data-api.js
@@ -27,8 +27,9 @@ function loadWidgets(name, widgetInit) {
       // Use browser globals to init widget if available
       if (window.ciscospark.widget) {
         const widgetObj = window.ciscospark.widget(widget);
-        if (typeof widgetObj[name] === `function`) {
-          widgetObj[name](props);
+        const widgetName = `${name}Widget`;
+        if (typeof widgetObj[widgetName] === `function`) {
+          widgetObj[widgetName](props);
         }
       }
       else {

--- a/packages/node_modules/@ciscospark/widget-base/src/data-api.js
+++ b/packages/node_modules/@ciscospark/widget-base/src/data-api.js
@@ -24,7 +24,16 @@ function loadWidgets(name, widgetInit) {
     if (typeof widgetInit === `function`) {
       // grab all data attributes that are not data-toggle
       const props = getDataAttributes(widget);
-      widgetInit(widget, props);
+      // Use browser globals to init widget if available
+      if (window.ciscospark.widget) {
+        const widgetObj = window.ciscospark.widget(widget);
+        if (typeof widgetObj[name] === `function`) {
+          widgetObj[name](props);
+        }
+      }
+      else {
+        widgetInit(widget, props);
+      }
     }
   }
 }


### PR DESCRIPTION
First pass at adding events for data api. This basically allows the data api to use browser globals to init the widgets and essentially give you access to the `window.ciscospark.widget(el)` method. By doing this we also hook in the ampersand events, and provide access to the widgets through global stores.

Another option would be to init the data api based widgets different, but I figured that would be a pain to maintain and cause confusion.