### PR TITLE
fix(widget-message): add detail is listening flags

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-conversation/src/reducer.js
@@ -21,7 +21,8 @@ export const initialState = fromJS({
     isLoaded: false,
     isLoadingHistoryUp: false,
     isLoadingMissing: false,
-    isListening: false,
+    isListeningToActivity: false,
+    isListeningToTyping: false,
     error: null
   }
 });

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -240,9 +240,11 @@ export class MessageWidget extends Component {
     const {props} = this;
     const prevConversation = props.conversation;
     const id = conversation.get(`id`);
-    if (!conversation.getIn([`status`, `isListening`])) {
-      this.listenToTypingEvents(id, sparkInstance);
+    if (!conversation.getIn([`status`, `isListeningToActivity`])) {
       this.listenToNewActivity(space, sparkInstance);
+    }
+    if (!conversation.getIn([`status`, `isListeningToTyping`])) {
+      this.listenToTypingEvents(id, sparkInstance);
     }
     if (!flags.hasFetched && !flags.isFetching) {
       nextProps.fetchFlags(sparkInstance);
@@ -267,7 +269,7 @@ export class MessageWidget extends Component {
    */
   listenToTypingEvents(conversationId, sparkInstance) {
     const {props} = this;
-    props.updateMercuryState({isListening: true});
+    props.updateMercuryState({isListeningToTyping: true});
     sparkInstance.internal.mercury.on(`event:status.start_typing`, (event) => {
       if (event.data.conversationId === conversationId) {
         props.setTyping(event.data.actor.id, true);
@@ -292,6 +294,7 @@ export class MessageWidget extends Component {
     const {props} = this;
     const handleEvent = this.handleEvent;
     const toUser = space.toPerson;
+    props.updateMercuryState({isListeningToActivity: true});
     sparkInstance.internal.mercury.on(`event:conversation.activity`, (event) => {
       const activity = event.data.activity;
       const isSelf = activity.actor.id === props.user.get(`currentUser`).id;


### PR DESCRIPTION
Noticed the `isListening` flag was being used for both activity and typing. Setting this to be more explicit