### PR TITLE
Avatar fetching

### DIFF
--- a/packages/node_modules/@ciscospark/react-container-read-receipts/src/index.js
+++ b/packages/node_modules/@ciscospark/react-container-read-receipts/src/index.js
@@ -1,17 +1,27 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 
 import classNames from 'classnames';
 
 import {getReadReceipts} from './selectors';
 
+import {fetchAvatarsForUsers} from '@ciscospark/redux-module-avatar';
 import TypingAvatar from '@ciscospark/react-component-typing-avatar';
 import Badge from '@ciscospark/react-component-badge';
 
 import styles from './styles.css';
 
 export class ReadReceipts extends Component {
+  componentWillReceiveProps(nextProps) {
+    const {users} = this.props.readReceipts;
+    const nextUsers = nextProps.readReceipts.users;
+    if (users !== nextUsers) {
+      this.props.fetchAvatarsForUsers(nextUsers.map((user) => user.userId), this.props.sparkInstance);
+    }
+  }
+
   shouldComponentUpdate(nextProps) {
     const {props} = this;
     return nextProps.readReceipts !== props.readReceipts;
@@ -30,7 +40,7 @@ export class ReadReceipts extends Component {
     const remainingUsers = totalCount - users.length;
     if (remainingUsers) {
       readReceipts.push(
-        <Badge>
+        <Badge key={`${remainingUsers}-remaining`}>
           {`+${remainingUsers}`}
         </Badge>
       );
@@ -44,16 +54,22 @@ export class ReadReceipts extends Component {
   }
 }
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
   return {
-    readReceipts: getReadReceipts(state)
+    readReceipts: getReadReceipts(state),
+    sparkInstance: ownProps.sparkInstance || state.spark.get(`spark`)
   };
 }
 
 ReadReceipts.propTypes = {
-  readReceipts: PropTypes.object
+  fetchAvatarsForUsers: PropTypes.func.isRequired,
+  readReceipts: PropTypes.object,
+  sparkInstance: PropTypes.object
 };
 
 export default connect(
-  mapStateToProps
+  mapStateToProps,
+  (dispatch) => bindActionCreators({
+    fetchAvatarsForUsers
+  }, dispatch)
 )(ReadReceipts);

--- a/packages/node_modules/@ciscospark/redux-module-avatar/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-avatar/src/__snapshots__/index.test.js.snap
@@ -22,6 +22,24 @@ exports[`redux-module-avatar actions  #fetchAvatarForUserId does not fetch an av
 
 exports[`redux-module-avatar actions  #fetchAvatarForUserId does not fetch an avatar in flight 1`] = `Array []`;
 
+exports[`redux-module-avatar actions  #fetchAvatarForUserId handles errors from the people plugin 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "userId": "abc-123",
+    },
+    "type": "avatar/ADD_AVATAR_BEGIN",
+  },
+  Object {
+    "payload": Object {
+      "avatar": undefined,
+      "userId": "abc-123",
+    },
+    "type": "avatar/ADD_AVATAR",
+  },
+]
+`;
+
 exports[`redux-module-avatar actions  #fetchAvatarsForUsers can fetch avatars for all users 1`] = `
 Array [
   Object {

--- a/packages/node_modules/@ciscospark/redux-module-avatar/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-avatar/src/__snapshots__/index.test.js.snap
@@ -17,3 +17,56 @@ Array [
   },
 ]
 `;
+
+exports[`redux-module-avatar actions  #fetchAvatarForUserId does not fetch an avatar already fetched 1`] = `Array []`;
+
+exports[`redux-module-avatar actions  #fetchAvatarForUserId does not fetch an avatar in flight 1`] = `Array []`;
+
+exports[`redux-module-avatar actions  #fetchAvatarsForUsers can fetch avatars for all users 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "userId": "a",
+    },
+    "type": "avatar/ADD_AVATAR_BEGIN",
+  },
+  Object {
+    "payload": Object {
+      "userId": "b",
+    },
+    "type": "avatar/ADD_AVATAR_BEGIN",
+  },
+  Object {
+    "payload": Object {
+      "avatar": Object {},
+      "userId": "a",
+    },
+    "type": "avatar/ADD_AVATAR",
+  },
+  Object {
+    "payload": Object {
+      "avatar": Object {},
+      "userId": "b",
+    },
+    "type": "avatar/ADD_AVATAR",
+  },
+]
+`;
+
+exports[`redux-module-avatar actions  #fetchAvatarsForUsers only fetches avatars not in flight and fetched 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "userId": "a-new-user",
+    },
+    "type": "avatar/ADD_AVATAR_BEGIN",
+  },
+  Object {
+    "payload": Object {
+      "avatar": Object {},
+      "userId": "a-new-user",
+    },
+    "type": "avatar/ADD_AVATAR",
+  },
+]
+`;

--- a/packages/node_modules/@ciscospark/redux-module-avatar/src/index.js
+++ b/packages/node_modules/@ciscospark/redux-module-avatar/src/index.js
@@ -22,9 +22,37 @@ export default function reducer(state = initialState, action) {
   }
 }
 
-
-export function fetchAvatarForUserId(userId, spark) {
+/**
+ * Fetches a group of users' avatars
+ * @param {Array} userIds
+ * @param {object} spark
+ * @returns {Thunk}
+ */
+export function fetchAvatarsForUsers(userIds, spark) {
+  const promises = [];
   return (dispatch) => {
+    userIds.forEach((userId) => {
+      promises.push(dispatch(fetchAvatarForUserId(userId, spark)));
+    });
+    return Promise.all(promises);
+  };
+}
+
+/**
+ * Fetches an avatar for a given user id
+ * @param {string} userId
+ * @param {object} spark
+ * @returns {Thunk}
+ */
+export function fetchAvatarForUserId(userId, spark) {
+  return (dispatch, getState) => {
+    const state = getState().avatar;
+    const fetched = state.hasIn([`items`, userId]);
+    const fetching = state.hasIn([`avatarsInFlight`, userId]);
+    if (fetched || fetching) {
+      return Promise.resolve();
+    }
+
     dispatch(addAvatarBegin(userId));
     return spark.people.get(userId)
       .then((person) => dispatch(addAvatar(userId, person.avatar)));

--- a/packages/node_modules/@ciscospark/redux-module-avatar/src/index.js
+++ b/packages/node_modules/@ciscospark/redux-module-avatar/src/index.js
@@ -55,7 +55,8 @@ export function fetchAvatarForUserId(userId, spark) {
 
     dispatch(addAvatarBegin(userId));
     return spark.people.get(userId)
-      .then((person) => dispatch(addAvatar(userId, person.avatar)));
+      .then((person) => dispatch(addAvatar(userId, person.avatar)))
+      .catch(() => dispatch(addAvatar(userId, undefined)));
   };
 }
 

--- a/packages/node_modules/@ciscospark/redux-module-avatar/src/index.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-avatar/src/index.test.js
@@ -14,6 +14,7 @@ const person = {
   avatar: {}
 };
 
+let mockState = {};
 
 describe(`redux-module-avatar actions `, () => {
   beforeEach(() => {
@@ -22,22 +23,71 @@ describe(`redux-module-avatar actions `, () => {
         get: jest.fn(() => Promise.resolve(person))
       }
     };
+
+    mockState = {avatar: initialState};
   });
 
   it(`has exported actions`, () => {
     expect(actions.fetchAvatarForUserId).toBeDefined();
+    expect(actions.fetchAvatarsForUsers).toBeDefined();
   });
 
   describe(`#fetchAvatarForUserId`, () => {
 
     it(`can fetch an Avatar`, () => {
-      const store = mockStore(initialState);
+      const store = mockStore(mockState);
       return store.dispatch(actions.fetchAvatarForUserId(`userId`, mockSpark))
         .then(() => {
           expect(mockSpark.people.get).toHaveBeenCalled();
           expect(store.getActions()).toMatchSnapshot();
         });
+    });
 
+    it(`does not fetch an avatar already fetched`, () => {
+      const userId = `abc-123`;
+      mockState.avatar = mockState.avatar.setIn([`items`, userId], {mocked: true});
+      const store = mockStore(mockState);
+      return store.dispatch(actions.fetchAvatarForUserId(userId, mockSpark))
+        .then(() => {
+          expect(mockSpark.people.get).not.toHaveBeenCalled();
+          expect(store.getActions()).toMatchSnapshot();
+        });
+    });
+
+    it(`does not fetch an avatar in flight`, () => {
+      const userId = `abc-123`;
+      mockState.avatar = mockState.avatar.setIn([`avatarsInFlight`, userId], {mocked: true});
+      const store = mockStore(mockState);
+      return store.dispatch(actions.fetchAvatarForUserId(userId, mockSpark))
+        .then(() => {
+          expect(mockSpark.people.get).not.toHaveBeenCalled();
+          expect(store.getActions()).toMatchSnapshot();
+        });
+    });
+  });
+
+  describe(`#fetchAvatarsForUsers`, () => {
+    it(`can fetch avatars for all users`, () => {
+      const store = mockStore(mockState);
+      return store.dispatch(actions.fetchAvatarsForUsers([`a`, `b`], mockSpark))
+        .then(() => {
+          expect(mockSpark.people.get).toHaveBeenCalledTimes(2);
+          expect(store.getActions()).toMatchSnapshot();
+        });
+    });
+
+    it(`only fetches avatars not in flight and fetched`, () => {
+      const userId1 = `abc-123`;
+      const userId2 = `abc-1234`;
+      const aNewUser = `a-new-user`;
+      mockState.avatar = mockState.avatar.setIn([`items`, userId1], {mocked: true});
+      mockState.avatar = mockState.avatar.setIn([`avatarsInFlight`, userId2], {mocked: true});
+      const store = mockStore(mockState);
+      return store.dispatch(actions.fetchAvatarsForUsers([userId1, userId2, aNewUser], mockSpark))
+        .then(() => {
+          expect(mockSpark.people.get).toHaveBeenCalledTimes(1);
+          expect(store.getActions()).toMatchSnapshot();
+        });
     });
   });
 });

--- a/packages/node_modules/@ciscospark/redux-module-avatar/src/index.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-avatar/src/index.test.js
@@ -64,6 +64,17 @@ describe(`redux-module-avatar actions `, () => {
           expect(store.getActions()).toMatchSnapshot();
         });
     });
+
+    it(`handles errors from the people plugin`, () => {
+      const userId = `abc-123`;
+      const store = mockStore(mockState);
+      mockSpark.people.get = jest.fn(() => Promise.reject());
+      return store.dispatch(actions.fetchAvatarForUserId(userId, mockSpark))
+        .then(() => {
+          expect(mockSpark.people.get).toHaveBeenCalled();
+          expect(store.getActions()).toMatchSnapshot();
+        });
+    });
   });
 
   describe(`#fetchAvatarsForUsers`, () => {

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/__snapshots__/actions.test.js.snap
@@ -97,26 +97,6 @@ Array [
 ]
 `;
 
-exports[`redux-module-space actions  #fetchSpaceAvatar properly fetches direct space avatar 1`] = `
-Array [
-  Object {
-    "payload": Object {
-      "spaceId": "spaceId",
-    },
-    "type": "spaces/FETCHING_AVATAR",
-  },
-  Object {
-    "payload": Object {
-      "avatar": Object {
-        "url": "https://avatar-url",
-      },
-      "spaceId": "spaceId",
-    },
-    "type": "spaces/STORE_AVATAR",
-  },
-]
-`;
-
 exports[`redux-module-space actions  #fetchSpaceAvatar properly fetches group space avatar 1`] = `
 Array [
   Object {

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
@@ -50,17 +50,9 @@ export function initialFetchSpaces(sparkInstance) {
 
 export function fetchSpaceAvatar(sparkInstance, space) {
   return (dispatch) => {
-    const currentUserId = sparkInstance.internal.device.userId;
     dispatch(fetchingAvatar(space.id));
     if (space.type === `direct`) {
-      // Support for direct messages with users who no longer exist
-      if (space.participants.length > 1) {
-        const otherUserId = space.participants.find((p) => p.id !== currentUserId).id;
-        return sparkInstance.people.get(otherUserId)
-          .then((person) => {
-            dispatch(storeAvatar(space.id, {url: person.avatar}));
-          });
-      }
+      return Promise.reject(new Error(`Direct spaces should use avatar service`));
     }
     else if (space.avatar) {
       return sparkInstance.internal.conversation.download(space.avatar.files.items[0])

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.test.js
@@ -161,13 +161,10 @@ describe(`redux-module-space actions `, () => {
 
 
   describe(`#fetchSpaceAvatar`, () => {
-    it(`properly fetches direct space avatar`, () => {
+    it(`throws error when fetching direct space avatar`, () => {
       space.type = `direct`;
       Reflect.deleteProperty(space, `avatar`);
-      store.dispatch(actions.fetchSpaceAvatar(mockSpark, space)).then(() => {
-        expect(mockSpark.people.get).toHaveBeenCalled();
-        expect(store.getActions()).toMatchSnapshot();
-      });
+      expect(actions.fetchSpaceAvatar(mockSpark, space)).toThrow();
     });
 
     it(`properly fetches group space avatar`, () => {

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -10,7 +10,7 @@ import autobind from 'autobind-decorator';
 import {
   constructFiles
 } from '@ciscospark/react-component-utils';
-import {fetchAvatarForUserId} from '@ciscospark/redux-module-avatar';
+import {fetchAvatarsForUsers} from '@ciscospark/redux-module-avatar';
 import {
   acknowledgeActivityOnServer,
   createConversation,
@@ -397,7 +397,7 @@ export class MessageWidget extends Component {
           userIds.push(userId);
         }
       });
-    userIds.forEach((userId) => props.fetchAvatarForUserId(userId, sparkInstance));
+    props.fetchAvatarsForUsers(userIds, sparkInstance);
   }
 
   /**
@@ -666,7 +666,7 @@ const injectedPropTypes = {
   createConversation: PropTypes.func.isRequired,
   createNotification: PropTypes.func.isRequired,
   deleteActivityAndDismiss: PropTypes.func.isRequired,
-  fetchAvatarForUserId: PropTypes.func.isRequired,
+  fetchAvatarsForUsers: PropTypes.func.isRequired,
   fetchFlags: PropTypes.func.isRequired,
   flagActivity: PropTypes.func.isRequired,
   getConversation: PropTypes.func.isRequired,
@@ -709,7 +709,7 @@ export default connect(
     createConversation,
     createNotification,
     deleteActivityAndDismiss,
-    fetchAvatarForUserId,
+    fetchAvatarsForUsers,
     fetchFlags,
     flagActivity,
     getConversation,

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -249,13 +249,12 @@ export class MessageWidget extends Component {
       nextProps.fetchFlags(sparkInstance);
     }
     // We only want to fetch avatars when a new activity is seen
-    const participantCount = conversation.get(`participants`).count();
-    const prevParticipants = prevConversation.get(`participants`);
-    if (prevParticipants) {
-      if (participantCount && participantCount !== prevParticipants.count()) {
-        this.getAvatarsFromConversation(conversation);
-      }
+    const activityCount = conversation.get(`activities`).count();
+    const prevActivities = prevConversation.get(`activities`);
+    if (activityCount && activityCount !== prevActivities.count()) {
+      this.getAvatarsFromConversation(conversation);
     }
+
     this.listenToBufferState(id, sparkInstance);
   }
 
@@ -387,16 +386,16 @@ export class MessageWidget extends Component {
   getAvatarsFromConversation(conversation) {
     const {props} = this;
     const {
-      avatar,
       sparkInstance
     } = props;
-    const participants = conversation.get(`participants`);
-    const userIds = _.uniq(participants.map((participant) => participant.get(`id`)).toJS())
-      .filter((userId) => {
-        // Only return users that haven't been fetched or is fetching
-        const fetched = avatar.hasIn([`items`, userId]);
-        const fetching = avatar.hasIn([`avatarsInFlight`, userId]);
-        return !fetched || !fetching;
+    const activities = conversation.get(`activities`);
+    const userIds = [];
+    activities
+      .forEach((activity) => {
+        const userId = activity.actor.id;
+        if (userIds.indexOf(userId) === -1) {
+          userIds.push(userId);
+        }
       });
     userIds.forEach((userId) => props.fetchAvatarForUserId(userId, sparkInstance));
   }

--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -19,6 +19,7 @@ import {
   initialFetchSpaces,
   updateSpaceWithActivity
 } from '@ciscospark/redux-module-spaces';
+import {fetchAvatarForUserId} from '@ciscospark/redux-module-avatar';
 import {events as metricEvents} from '@ciscospark/react-redux-spark-metrics';
 import {connectToMercury} from '@ciscospark/redux-module-mercury';
 import IncomingCall from '@ciscospark/react-component-incoming-call';
@@ -119,7 +120,18 @@ export class RecentsWidget extends Component {
           this.listenForCall(sparkInstance, props);
         }
         spaces.get(`items`).forEach((s) => {
-          if (!spaces.getIn([`avatars`, s.get(`id`)])) {
+          if (s.get(`type`) === `direct`) {
+            if (s.get(`participants`).count() > 1) {
+              // Get the user ID of the participant that isn't current user
+              const currentUserId = user.get(`currentUser`).id;
+              const otherUser = s.get(`participants`).find((p) => p.get(`id`) !== currentUserId);
+              if (otherUser) {
+                const otherUserId = otherUser.get(`id`);
+                props.fetchAvatarForUserId(otherUserId, sparkInstance);
+              }
+            }
+          }
+          else if (!spaces.getIn([`avatars`, s.get(`id`)])) {
             props.fetchSpaceAvatar(sparkInstance, s.toJS());
           }
         });
@@ -493,6 +505,7 @@ const injectedPropTypes = {
   widgetRecents: PropTypes.object,
   addError: PropTypes.func,
   connectToMercury: PropTypes.func,
+  fetchAvatarForUserId: PropTypes.func,
   removeError: PropTypes.func,
   updateWidgetStatus: PropTypes.func
 };
@@ -517,6 +530,7 @@ export default connect(
     acknowledgeSpace,
     addError,
     connectToMercury,
+    fetchAvatarForUserId,
     fetchCurrentUser,
     fetchSpace,
     fetchSpaceAvatar,

--- a/packages/node_modules/@ciscospark/widget-recents/src/reducer.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/reducer.js
@@ -3,6 +3,7 @@ import mercury from '@ciscospark/redux-module-mercury';
 import user from '@ciscospark/redux-module-user';
 import spaces from '@ciscospark/redux-module-spaces';
 import errors from '@ciscospark/redux-module-errors';
+import avatar from '@ciscospark/redux-module-avatar';
 
 import {
   UPDATE_STATUS,
@@ -37,6 +38,7 @@ export function reducer(state = initialState, action) {
 }
 
 const reducers = {
+  avatar,
   user,
   mercury,
   spaces,

--- a/packages/node_modules/@ciscospark/widget-recents/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/selector.js
@@ -10,14 +10,13 @@ const getSpaces = (state) => state.spaces;
 const getMedia = (state) => state.media;
 
 
-function constructSpace(space, avatars) {
+function constructSpace(space, avatarUrl) {
 
   const lastSeenActivityDate = space.get(`lastSeenActivityDate`);
   const lastActivityTimestamp = space.get(`lastReadableActivityDate`);
   const isUnread = lastSeenActivityDate ? moment(lastSeenActivityDate).isBefore(lastActivityTimestamp) : true;
 
   const id = space.get(`id`);
-  const avatarUrl = avatars.getIn([id, `url`]);
   const actorName = space.getIn([`latestActivity`, `actor`, `displayName`]);
 
   return {
@@ -40,7 +39,14 @@ function constructSpace(space, avatars) {
 }
 
 function constructOneOnOne(space, currentUser, avatars) {
-  const thisSpace = constructSpace(space, avatars);
+  // Get the user ID of the participant that isn't current user
+  let avatarUrl;
+  const otherUser = space.get(`participants`).find((p) => p.get(`id`) !== currentUser.id);
+  if (otherUser) {
+    const otherUserId = otherUser.get(`id`);
+    avatarUrl = avatars.get(otherUserId);
+  }
+  const thisSpace = constructSpace(space, avatarUrl);
   const currentUserEmail = currentUser.email;
   const otherUsers = space.get(`participants`)
     .find((p) => p.get(`emailAddress`) !== currentUserEmail);
@@ -57,7 +63,9 @@ function constructOneOnOne(space, currentUser, avatars) {
 }
 
 function constructGroup(space, avatars) {
-  const thisSpace = constructSpace(space, avatars);
+  const id = space.get(`id`);
+  const avatarUrl = avatars.getIn([id, `url`]);
+  const thisSpace = constructSpace(space, avatarUrl);
   if (space.get(`displayName`)) {
     thisSpace.name = space.get(`displayName`);
   }
@@ -74,16 +82,17 @@ function constructGroup(space, avatars) {
 }
 
 const getRecentSpaces = createSelector(
-  [getSpaces, getUsers],
-  (spaces, users) => {
+  [getSpaces, getUsers, getAvatars],
+  (spaces, users, avatars) => {
     const currentUser = users.get(`currentUser`);
-    const avatars = spaces.get(`avatars`);
+    const spaceAvatars = spaces.get(`avatars`);
+    const userAvatars = avatars.get(`items`);
     const recents = spaces.get(`items`)
       .map((space) => {
         if (space.get(`type`) === `direct`) {
-          return constructOneOnOne(space, currentUser, avatars);
+          return constructOneOnOne(space, currentUser, userAvatars);
         }
-        return constructGroup(space, avatars);
+        return constructGroup(space, spaceAvatars);
       });
     return recents;
   }


### PR DESCRIPTION
This turned out a bit bigger than expected, so you may want to go commit by commit.

Basically, all individual avatar handling is now in the avatar module. You can call "fetch avatar" over and over for a user and it will only process if we haven't seen that user before. 

There's also some cleanup in spaces widget to only get the avatars we need for display instead of **EVERYONE**