### PR TITLE
chore: add greenkeeper ignore for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,5 +155,17 @@
     "webdriverio": "^4.6.2",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^2.2.0"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "eslint",
+      "eslint-config",
+      "eslint-config-airbnb",
+      "eslint-plugin-babel",
+      "eslint-plugin-import",
+      "eslint-plugin-jsx-a11y",
+      "eslint-plugin-mocha",
+      "eslint-plugin-react"
+    ]
   }
 }


### PR DESCRIPTION
Since we are locked to the sdk's eslint version, let's not get greenkeeper updates on it in this repo.