### PR TITLE
Convert demos to use widget bundles and global methods

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,9 +129,9 @@ ansiColor('xterm') {
               BUILD_PUBLIC_PATH="https://code.s4d.io/widget-message-meet/archives/${version}/demo/" npm run build:package widget-message-meet-demo
               BUILD_PUBLIC_PATH="https://code.s4d.io/widget-message-meet/archives/${version}/" npm run build:package widget-message-meet
               BUILD_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${version}/" npm run build:package widget-space
-              BUILD_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${version}/demo/" npm run build:package widget-space-demo
+              BUILD_BUNDLE_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${version}/" BUILD_PUBLIC_PATH="https://code.s4d.io/widget-space/archives/${version}/demo/" npm run build:package widget-space-demo
               BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${version}/" npm run build:package widget-recents
-              BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${version}/demo/" npm run build:package widget-recents-demo
+              BUILD_BUNDLE_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${version}/" BUILD_PUBLIC_PATH="https://code.s4d.io/widget-recents/archives/${version}/demo/" npm run build:package widget-recents-demo
               '''
             }
           }

--- a/packages/node_modules/@ciscospark/widget-recents-demo/src/components/demo-widget-recents/index.js
+++ b/packages/node_modules/@ciscospark/widget-recents-demo/src/components/demo-widget-recents/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-set-state,react/forbid-component-props,react/jsx-no-literals */
+/* global ciscospark */
 import React, {Component} from 'react';
 import {instanceOf} from 'prop-types';
 import classNames from 'classnames';
@@ -14,11 +15,11 @@ import {Card, CardActions, CardTitle, CardText} from 'material-ui/Card';
 import Highlight from 'react-highlight';
 import 'highlight.js/styles/default.css';
 
-import WidgetRecents from '@ciscospark/widget-recents';
-
 import TokenInput from '../token-input';
 
 import styles from './styles.css';
+
+const widgetElementId = `my-ciscospark-widget`;
 
 class DemoWidgetRecents extends Component {
   componentWillMount() {
@@ -42,6 +43,10 @@ class DemoWidgetRecents extends Component {
     e.preventDefault();
     const {cookies} = this.props;
     cookies.set(`accessToken`, this.state.accessToken);
+    const widgetEl = document.getElementById(widgetElementId);
+    ciscospark.widget(widgetEl).recentsWidget({
+      accessToken: this.state.accessToken
+    });
     this.setState({running: true});
   }
 
@@ -55,19 +60,11 @@ class DemoWidgetRecents extends Component {
     return this.setState({displayToken});
   }
 
-  createWidget(e) {
-    e.preventDefault();
-    return this.setState({running: true});
-  }
-
   // eslint-disable-next-line complexity
   generateExampleCode(state) {
     const {accessToken, displayToken} = state;
     const displayedAccessToken = displayToken ? accessToken : `YOUR_ACCESS_TOKEN`;
 
-    const reactCode = `import RecentsWidget from '@ciscospark/widget-recents';
-
-<RecentsWidget accessToken="${displayedAccessToken}" />`;
     const inlineCode = `<div data-toggle="ciscospark-recents" data-access-token="${displayedAccessToken}" />`;
     const globalCode = `<div id="my-ciscospark-widget" />
 <script>
@@ -79,29 +76,27 @@ class DemoWidgetRecents extends Component {
 </script>`;
     return {
       globalCode,
-      inlineCode,
-      reactCode
+      inlineCode
     };
   }
 
   render() {
     const loadButtonEnabled = this.state.accessToken;
-    const {globalCode, inlineCode, reactCode} = this.generateExampleCode(this.state);
-    if (this.state.running) {
-      return (
-        <div>
-          <AppBar title="Cisco Spark Recents Widget" />
-          <div className={classNames(`ciscospark-widget-component-container`, styles.widgetComponentContainer)}>
-            <WidgetRecents
-              accessToken={this.state.accessToken}
-            />
-          </div>
-        </div>
-      );
+    const {globalCode, inlineCode} = this.generateExampleCode(this.state);
+    const componentContainerClassNames = [
+      `ciscospark-widget-component-container`,
+      styles.widgetComponentContainer
+    ];
+    if (!this.state.running) {
+      componentContainerClassNames.push(styles.hidden);
     }
+
     return (
       <div>
         <AppBar title="Cisco Spark Recents Widget" />
+        <div className={classNames(componentContainerClassNames)}>
+          <div id={widgetElementId} />
+        </div>
         <div className={classNames(`ciscospark-demo-wrapper`, styles.demoWrapper)}>
           <Card initiallyExpanded style={{margin: `10px`}}>
             <CardTitle
@@ -140,13 +135,6 @@ class DemoWidgetRecents extends Component {
             <CardText expandable>
               <div className={classNames(styles.example)}>
                 <Tabs>
-                  <Tab label={`React Component`}>
-                    <div className={classNames(`ciscospark-example-code`, styles.exampleCode)}>
-                      <Highlight>
-                        {reactCode}
-                      </Highlight>
-                    </div>
-                  </Tab>
                   <Tab label={`Inline Mode`}>
                     <div className={classNames(`ciscospark-example-code`, styles.exampleCode)}>
                       <Highlight>

--- a/packages/node_modules/@ciscospark/widget-recents-demo/src/components/demo-widget-recents/styles.css
+++ b/packages/node_modules/@ciscospark/widget-recents-demo/src/components/demo-widget-recents/styles.css
@@ -31,12 +31,14 @@
 }
 
 .widget-component-container {
-  position: absolute;
+  position: fixed;
   left: 0px;
   bottom: 0px;
   width: 500px;
   height: 600px;
   border: 1px solid;
+  background-color: white;
+  z-index: 99;
 }
 
 .widget-component-container > div {
@@ -75,4 +77,8 @@
 
 .select label {
   left: 0;
+}
+
+.hidden {
+  visibility: hidden;
 }

--- a/packages/node_modules/@ciscospark/widget-recents-demo/src/index.html
+++ b/packages/node_modules/@ciscospark/widget-recents-demo/src/index.html
@@ -8,9 +8,11 @@
       margin: 0;
     }
     </style>
+    <%= htmlWebpackPlugin.options.bundlePaths.styleBundle %>
   </head>
   <body>
     <div id="widget"></div>
     <div id="main"></div>
+    <%= htmlWebpackPlugin.options.bundlePaths.scriptBundle %>
   </body>
 </html>

--- a/packages/node_modules/@ciscospark/widget-recents-demo/src/index.js
+++ b/packages/node_modules/@ciscospark/widget-recents-demo/src/index.js
@@ -15,6 +15,11 @@ import {blue600, green800} from 'material-ui/styles/colors';
 
 import DemoWidgetRecents from './components/demo-widget-recents';
 
+if (process.env.NODE_ENV !== `production`) {
+  // eslint-disable-next-line global-require
+  require(`@ciscospark/widget-recents`);
+}
+
 const muiTheme = getMuiTheme({
   palette: {
     primary1Color: blue600,

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/index.js
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-set-state,react/forbid-component-props,react/jsx-no-literals */
+/* global ciscospark */
 import React, {Component} from 'react';
 import classNames from 'classnames';
 import {Cookies, withCookies} from 'react-cookie';
@@ -17,8 +18,6 @@ import {Card, CardActions, CardTitle, CardText} from 'material-ui/Card';
 import Highlight from 'react-highlight';
 import 'highlight.js/styles/default.css';
 
-import WidgetSpace from '@ciscospark/widget-space';
-
 import TokenInput from '../token-input';
 
 import styles from './styles.css';
@@ -26,6 +25,7 @@ import styles from './styles.css';
 const MODE_ONE_ON_ONE = `MODE_ONE_ON_ONE`;
 const MODE_SPACE = `MODE_SPACE`;
 
+const widgetElementId = `my-ciscospark-widget`;
 
 class DemoWidgetSpace extends Component {
   constructor(props) {
@@ -47,7 +47,9 @@ class DemoWidgetSpace extends Component {
       displayToken: false,
       hasToken,
       mode,
-      running: false
+      running: false,
+      toPersonEmail,
+      spaceId
     };
   }
 
@@ -65,6 +67,21 @@ class DemoWidgetSpace extends Component {
     }
     else {
       cookies.set(`spaceId`, this.state.spaceId);
+    }
+    const toPerson = this.state.mode === MODE_ONE_ON_ONE ? this.state.toPersonEmail : ``;
+    const toSpace = this.state.mode === MODE_SPACE ? this.state.spaceId : ``;
+    const widgetEl = document.getElementById(widgetElementId);
+    if (toPerson) {
+      ciscospark.widget(widgetEl).spaceWidget({
+        accessToken: this.state.accessToken,
+        toPersonEmail: toPerson
+      });
+    }
+    if (toSpace) {
+      ciscospark.widget(widgetEl).spaceWidget({
+        accessToken: this.state.accessToken,
+        spaceId: toSpace
+      });
     }
     this.setState({running: true});
   }
@@ -94,30 +111,20 @@ class DemoWidgetSpace extends Component {
     return this.setState({spaceId: e.target.value});
   }
 
-  createWidget(e) {
-    e.preventDefault();
-    return this.setState({running: true});
-  }
-
   // eslint-disable-next-line complexity
   generateExampleCode(state) {
     const {accessToken, displayToken, spaceId, toPersonEmail} = state;
     const displayedAccessToken = displayToken ? accessToken : `YOUR_ACCESS_TOKEN`;
-    let globalToField, inlineToField, reactToField;
+    let globalToField, inlineToField;
     if (this.state.mode === MODE_ONE_ON_ONE) {
       inlineToField = `data-to-person-email="${toPersonEmail ? toPersonEmail : `TO_PERSON_EMAIL`}"`;
-      reactToField = `toPersonEmail="${toPersonEmail ? toPersonEmail : `TO_PERSON_EMAIL`}"`;
       globalToField = `toPersonEmail: '${toPersonEmail ? toPersonEmail : `TO_PERSON_EMAIL`}'`;
     }
     else {
       globalToField = `spaceId: '${spaceId ? spaceId : `SPACE_ID`}'`;
       inlineToField = `data-space-id="${spaceId ? spaceId : `SPACE_ID`}"`;
-      reactToField = `spaceId="${spaceId ? spaceId : `SPACE_ID`}"`;
     }
 
-    const reactCode = `import SpaceWidget from '@ciscospark/widget-space';
-
-<SpaceWidget accessToken="${displayedAccessToken}" ${reactToField} />`;
     const inlineCode = `<div data-toggle="ciscospark-space" data-access-token="${displayedAccessToken}" ${inlineToField} />`;
     const globalCode = `<div id="my-ciscospark-widget" />
 <script>
@@ -130,36 +137,29 @@ class DemoWidgetSpace extends Component {
 </script>`;
     return {
       globalCode,
-      inlineCode,
-      reactCode
+      inlineCode
     };
   }
 
   render() {
     const hasToPerson = this.state.mode === MODE_ONE_ON_ONE && this.state.toPersonEmail;
     const hasToSpace = this.state.mode === MODE_SPACE && this.state.spaceId;
-    const toPerson = this.state.mode === MODE_ONE_ON_ONE ? this.state.toPersonEmail : ``;
-    const toSpace = this.state.mode === MODE_SPACE ? this.state.spaceId : ``;
     const loadButtonEnabled = this.state.accessToken && (hasToPerson || hasToSpace);
-    const {globalCode, inlineCode, reactCode} = this.generateExampleCode(this.state);
-    if (this.state.running) {
-      return (
-        <div>
-          <AppBar title="Cisco Spark Space Widget" />
-          <div className={classNames(`ciscospark-widget-component-container`, styles.widgetComponentContainer)}>
-            <WidgetSpace
-              accessToken={this.state.accessToken}
-              spaceId={toSpace}
-              toPersonEmail={toPerson}
-            />
-          </div>
-        </div>
-      );
+    const {globalCode, inlineCode} = this.generateExampleCode(this.state);
+    const componentContainerClassNames = [
+      styles.widgetComponentContainer
+    ];
+    if (!this.state.running) {
+      componentContainerClassNames.push(styles.hidden);
     }
+
     return (
       <div>
         <AppBar title="Cisco Spark Space Widget" />
         <div className={classNames(`ciscospark-demo-wrapper`, styles.demoWrapper)}>
+          <div className={classNames(componentContainerClassNames)}>
+            <div id={widgetElementId} />
+          </div>
           <Card initiallyExpanded style={{margin: `10px`}}>
             <CardTitle
               actAsExpander
@@ -236,13 +236,6 @@ class DemoWidgetSpace extends Component {
             <CardText expandable>
               <div className={classNames(styles.example)}>
                 <Tabs>
-                  <Tab label={`React Component`}>
-                    <div className={classNames(`ciscospark-example-code`, styles.exampleCode)}>
-                      <Highlight>
-                        {reactCode}
-                      </Highlight>
-                    </div>
-                  </Tab>
                   <Tab label={`Inline Mode`}>
                     <div className={classNames(`ciscospark-example-code`, styles.exampleCode)}>
                       <Highlight>

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/styles.css
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/styles.css
@@ -37,6 +37,7 @@
   width: 500px;
   height: 600px;
   z-index: 99;
+  background-color: white;
 }
 
 .widget-component-container > div {

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/styles.css
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/styles.css
@@ -31,11 +31,12 @@
 }
 
 .widget-component-container {
-  position: absolute;
+  position: fixed;
   right: 10px;
   bottom: 0;
   width: 500px;
   height: 600px;
+  z-index: 99;
 }
 
 .widget-component-container > div {
@@ -74,4 +75,8 @@
 
 .select label {
   left: 0;
+}
+
+.hidden {
+  visibility: hidden;
 }

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/index.html
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/index.html
@@ -8,9 +8,11 @@
       margin: 0;
     }
     </style>
+    <%= htmlWebpackPlugin.options.bundlePaths.styleBundle %>
   </head>
   <body>
     <div id="widget"></div>
     <div id="main"></div>
+    <%= htmlWebpackPlugin.options.bundlePaths.scriptBundle %>
   </body>
 </html>

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/index.js
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/index.js
@@ -15,6 +15,11 @@ import {blue600, green800} from 'material-ui/styles/colors';
 
 import DemoWidgetSpace from './components/demo-widget-space';
 
+if (process.env.NODE_ENV !== `production`) {
+  // eslint-disable-next-line global-require
+  require(`@ciscospark/widget-space`);
+}
+
 const muiTheme = getMuiTheme({
   palette: {
     primary1Color: blue600,

--- a/scripts/webpack/webpack.dev.babel.js
+++ b/scripts/webpack/webpack.dev.babel.js
@@ -9,7 +9,11 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 const plugins = [
   new HtmlWebpackPlugin({
-    template: `index.html`
+    template: `index.html`,
+    bundlePaths: {
+      scriptBundle: `<!-- Script should be in main bundle -->`,
+      styleBundle: `<!-- Style should be in main bundle -->`
+    }
   }),
   new webpack.EnvironmentPlugin([
     `CISCOSPARK_ACCESS_TOKEN`,

--- a/scripts/webpack/webpack.prod.babel.js
+++ b/scripts/webpack/webpack.prod.babel.js
@@ -21,6 +21,13 @@ const plugins = [
   new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
 ];
 
+// Bundle paths are used for demos only
+let scriptBundle, styleBundle;
+if (process.env.BUILD_BUNDLE_PUBLIC_PATH) {
+  scriptBundle = `<script src="${process.env.BUILD_BUNDLE_PUBLIC_PATH}bundle.js"></script>`;
+  styleBundle = `<link rel="stylesheet" href="${process.env.BUILD_BUNDLE_PUBLIC_PATH}main.css">`;
+}
+
 // Only create html file when one exists in src/
 if (fs.existsSync(`./src/index.html`)) {
   plugins.push(
@@ -34,7 +41,11 @@ if (fs.existsSync(`./src/index.html`)) {
         sortAttributes: true,
         sortClassName: true
       },
-      template: `./index.html`
+      template: `./index.html`,
+      bundlePaths: {
+        scriptBundle,
+        styleBundle
+      }
     })
   );
 }


### PR DESCRIPTION
Instead of building one giant bundle for demos, we will have the demo code be a bundle, then utilize the global method of actually creating and opening widgets.