### PR TITLE
fix(redux-module-teams): Fix wrong action names

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-teams/src/__snapshots__/index.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-teams/src/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ Array [
         "isFetching": true,
       },
     },
-    "type": "user/UPDATE_STATUS",
+    "type": "teams/UPDATE_STATUS",
   },
   Object {
     "payload": Object {
@@ -16,7 +16,7 @@ Array [
         "isFetching": false,
       },
     },
-    "type": "user/UPDATE_STATUS",
+    "type": "teams/UPDATE_STATUS",
   },
 ]
 `;

--- a/packages/node_modules/@ciscospark/redux-module-teams/src/index.js
+++ b/packages/node_modules/@ciscospark/redux-module-teams/src/index.js
@@ -1,7 +1,7 @@
 import {fromJS} from 'immutable';
 
-export const STORE_TEAMS = `user/STORE_TEAMS`;
-export const UPDATE_STATUS = `user/UPDATE_STATUS`;
+export const STORE_TEAMS = `teams/STORE_TEAMS`;
+export const UPDATE_STATUS = `teams/UPDATE_STATUS`;
 
 export const initialState = fromJS({
   items: {},


### PR DESCRIPTION
Fixes issue that causes looping retrieval of teams.