### PR TITLE
fix(redux-module-media): compute activeParticipantsCount for call state

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
@@ -209,7 +209,8 @@ export function checkWebRTCSupport(sparkInstance) {
 
 
 function constructCallState(call) {
-  let connected,
+  let activeParticipantsCount,
+    connected,
     remoteAudioMuted,
     remoteAudioStream,
     remoteVideoMuted,
@@ -236,12 +237,14 @@ function constructCallState(call) {
     else {
       connected = !!call.joinedOnThisDevice;
     }
+
+    activeParticipantsCount = call.memberships.filter((m) => m.state === `connected`).length;
   }
   catch (e) {
     // Do nothing
   }
   return {
-    activeParticipantsCount: call.activeParticipantsCount,
+    activeParticipantsCount,
     state: call.state,
     isCall: call.isCall,
     direction: call.direction,


### PR DESCRIPTION
Still needs investigation on the js-sdk side, but activeParticipantsCount needs to be manually calculated for now.

https://voxeolabs.atlassian.net/browse/SSDK-1421