### PR TITLE
Change demo inputs from TextField to input

### DIFF
--- a/packages/node_modules/@ciscospark/widget-recents-demo/src/components/token-input/index.js
+++ b/packages/node_modules/@ciscospark/widget-recents-demo/src/components/token-input/index.js
@@ -2,9 +2,10 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {autobind} from 'core-decorators';
-import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import {Card, CardActions, CardTitle, CardText} from 'material-ui/Card';
+
+import style from './styles.css';
 
 class TokenInput extends Component {
   constructor(props) {
@@ -49,12 +50,12 @@ class TokenInput extends Component {
           {!this.state.tokenSaved &&
           <CardText expandable>
             <p>You can get an access token from <a href="http://developer.ciscospark.com">{`developer.ciscospark.com`}</a></p>
-            <TextField
+            <input
               aria-label="Access Token"
-              floatingLabelFixed
-              floatingLabelText="Access Token"
-              hintText="Your Access Token"
+              className={style.textInput}
+              id="accessTokenInput"
               onChange={this.handleAccessTokenChange}
+              placeholder="Your Access Token"
               value={this.state.userAccessToken}
             />
           </CardText>
@@ -64,6 +65,7 @@ class TokenInput extends Component {
             <RaisedButton
               aria-label="Save Token"
               disabled={!this.state.userAccessToken}
+              id="accessTokenSaveButton"
               label={`Save Token`}
               onClick={this.handleSaveToken}
               primary

--- a/packages/node_modules/@ciscospark/widget-recents-demo/src/components/token-input/styles.css
+++ b/packages/node_modules/@ciscospark/widget-recents-demo/src/components/token-input/styles.css
@@ -1,0 +1,8 @@
+.text-input {
+  width: 75%;
+  margin: 15px;
+  font-size: 16px;
+  color: #39393b;
+  border: none;
+  border-bottom: 1px solid #1b1d1e;
+}

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/index.js
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/index.js
@@ -6,7 +6,6 @@ import {Cookies, withCookies} from 'react-cookie';
 import {instanceOf} from 'prop-types';
 import {autobind} from 'core-decorators';
 
-import TextField from 'material-ui/TextField';
 import {Tabs, Tab} from 'material-ui/Tabs';
 import RaisedButton from 'material-ui/RaisedButton';
 import AppBar from 'material-ui/AppBar';
@@ -210,26 +209,24 @@ class DemoWidgetSpace extends Component {
               </div>
               {this.state.mode === MODE_SPACE &&
               <div>
-                <TextField
+                <input
                   aria-label="To Space ID"
-                  floatingLabelFixed
-                  floatingLabelText="To Room/Space Id"
-                  hintText="Spark Space Id"
+                  className={styles.textInput}
                   id="toSpaceId"
                   onChange={this.handleSpaceChange}
+                  placeholder="Spark Space Id"
                   value={this.state.spaceId}
                 />
               </div>
               }
               {this.state.mode === MODE_ONE_ON_ONE &&
               <div>
-                <TextField
+                <input
                   aria-label="To User Email"
-                  floatingLabelFixed
-                  floatingLabelText="To User Email"
-                  hintText="Spark User Email (For 1:1)"
+                  className={styles.textInput}
                   id="toUserEmail"
                   onChange={this.handleEmailChange}
+                  placeholder="Spark User Email (For 1:1)"
                   value={this.state.toPersonEmail}
                 />
               </div>

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/styles.css
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/demo-widget-space/styles.css
@@ -84,3 +84,12 @@
 .hidden {
   visibility: hidden;
 }
+
+.text-input {
+  width: 75%;
+  margin: 15px;
+  font-size: 16px;
+  color: #39393b;
+  border: none;
+  border-bottom: 1px solid #1b1d1e;
+}

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/token-input/index.js
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/token-input/index.js
@@ -2,9 +2,10 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {autobind} from 'core-decorators';
-import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import {Card, CardActions, CardTitle, CardText} from 'material-ui/Card';
+
+import style from './styles.css';
 
 class TokenInput extends Component {
   constructor(props) {
@@ -49,13 +50,12 @@ class TokenInput extends Component {
           {!this.state.tokenSaved &&
           <CardText expandable>
             <p>You can get an access token from <a href="http://developer.ciscospark.com">{`developer.ciscospark.com`}</a></p>
-            <TextField
+            <input
               aria-label="Access Token"
-              floatingLabelFixed
-              floatingLabelText="Access Token"
-              hintText="Your Access Token"
+              className={style.textInput}
               id="accessTokenInput"
               onChange={this.handleAccessTokenChange}
+              placeholder="Your Access Token"
               value={this.state.userAccessToken}
             />
           </CardText>

--- a/packages/node_modules/@ciscospark/widget-space-demo/src/components/token-input/styles.css
+++ b/packages/node_modules/@ciscospark/widget-space-demo/src/components/token-input/styles.css
@@ -1,0 +1,8 @@
+.text-input {
+  width: 75%;
+  margin: 15px;
+  font-size: 16px;
+  color: #39393b;
+  border: none;
+  border-bottom: 1px solid #1b1d1e;
+}

--- a/test/journeys/specs/tap/upcoming.js.skip
+++ b/test/journeys/specs/tap/upcoming.js.skip
@@ -1,0 +1,66 @@
+/* eslint-disable max-nested-callbacks */
+
+import {assert} from 'chai';
+
+import '@ciscospark/internal-plugin-conversation';
+import '@ciscospark/plugin-logger';
+import testUsers from '@ciscospark/test-helper-test-users';
+import CiscoSpark from '@ciscospark/spark-core';
+
+describe(`Widget Space: Group Space: TAP`, () => {
+  const browserLocal = browser.select(`browserLocal`);
+  let marty;
+
+  process.env.CISCOSPARK_SCOPE = [
+    `webexsquare:get_conversation`,
+    `spark:people_read`,
+    `spark:rooms_read`,
+    `spark:rooms_write`,
+    `spark:memberships_read`,
+    `spark:memberships_write`,
+    `spark:messages_read`,
+    `spark:messages_write`,
+    `spark:teams_read`,
+    `spark:teams_write`,
+    `spark:team_memberships_read`,
+    `spark:team_memberships_write`,
+    `spark:kms`
+  ].join(` `);
+
+  before(`create marty`, () => testUsers.create({count: 1, config: {displayName: `Marty McFly`}})
+    .then((users) => {
+      [marty] = users;
+      marty.spark = new CiscoSpark({
+        credentials: {
+          authorization: marty.token
+        },
+        config: {
+          logger: {
+            level: `error`
+          }
+        }
+      });
+      return marty.spark.internal.mercury.connect();
+    }));
+
+  it(`loads the test page`, () => {
+    browserLocal
+      .url(`https://code.s4d.io/widget-space/latest/demo/index.html`);
+    const title = browserLocal.getTitle();
+    assert.equal(title, `Cisco Spark Space Widget Demo`);
+
+    browserLocal.waitUntil(() => browserLocal.element(`#accessTokenInput`).isVisible());
+    console.log(marty.token.access_token);
+    const token = marty.token.access_token;
+    // browserLocal.element(`#accessTokenInput`).setValue(token);
+    browserLocal.execute((myToken) => {
+      document.querySelector(`#accessTokenInput`).value = myToken;
+    }, token);
+    const BACKSPACE_UNICODE = `\uE003`;
+    browserLocal.element(`#accessTokenInput`)
+      .click()
+      .keys([` `, BACKSPACE_UNICODE]);
+    browserLocal.debug();
+  });
+
+});


### PR DESCRIPTION
A slow migration away from material UI. `<TextField>` does way too much and is difficult to work with via automation.