### PR TITLE
remove widget features and fixes

### DIFF
--- a/packages/node_modules/@ciscospark/widget-base/src/constructor.js
+++ b/packages/node_modules/@ciscospark/widget-base/src/constructor.js
@@ -96,7 +96,7 @@ export default function constructSparkWidget(widgetName, Widget, options = {}) {
   }
 
   function removeSparkWidget(el) {
-    ReactDOM.unmountComponentAtNode(el);
+    return ReactDOM.unmountComponentAtNode(el);
   }
 
   const registerTuple = [widgetName, initSparkWidget, removeSparkWidget];

--- a/packages/node_modules/@ciscospark/widget-meet/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-meet/src/container.js
@@ -122,6 +122,12 @@ export class MeetWidget extends Component {
       || nextProps.widgetMeet !== props.widgetMeet;
   }
 
+  componentWillUnmount() {
+    if (this.props.callIsActive) {
+      this.handleHangup();
+    }
+  }
+
   @autobind
   setup(props) {
     const {


### PR DESCRIPTION
There was a missing `return` in this function to propagate up to the `.remove` global function.