### PR TITLE
fix(widget-roster): fix name of the roster from incorrect 'message'

### DIFF
--- a/packages/node_modules/@ciscospark/widget-roster/src/index.js
+++ b/packages/node_modules/@ciscospark/widget-roster/src/index.js
@@ -13,7 +13,7 @@ import {reducer, reducers} from './reducer';
 export {reducer, reducers};
 
 export default constructSparkWidget(
-  `message`,
+  `roster`,
   ConnectedRoster,
   {
     reducers,


### PR DESCRIPTION
fixes #565