### PR TITLE
Recents - refresh space when a delete activity arrives

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/__snapshots__/actions.test.js.snap
@@ -1,5 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`redux-module-space actions  #fetchSpace filters delete messages from a space 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "space": Object {
+        "avatar": Object {
+          "contentCategory": "images",
+          "files": Object {
+            "items": Array [
+              Object {
+                "fileSize": 56520,
+                "mimeType": "image/png",
+                "objectType": "file",
+                "scr": Object {},
+                "url": "https://fileUrl",
+              },
+            ],
+          },
+          "objectType": "content",
+        },
+        "conversationWebUrl": "https://conversationWebUrl",
+        "displayName": "Space 1",
+        "id": "spaceId",
+        "lastReadableActivityDate": "2017-06-07T15:13:56.326Z",
+        "lastSeenActivityDate": "2017-06-07T15:13:34.505Z",
+        "latestActivity": Object {
+          "actor": Object {
+            "displayName": "Marty McFly",
+          },
+          "object": Object {
+            "displayName": "check this out!",
+          },
+          "verb": "post",
+        },
+        "participants": undefined,
+        "published": "2016-02-29T17:49:17.029Z",
+        "tags": Array [
+          "MUTED",
+          "FAVORITE",
+          "LOCKED",
+          "TEAM",
+          "JOINED",
+          "MESSAGE_NOTIFICATIONS_OFF",
+          "MENTION_NOTIFICATIONS_ON",
+        ],
+        "team": Object {
+          "archived": false,
+          "color": "#C589C5",
+          "displayName": "Test Team",
+          "generalConversationUuid": "spaceId",
+          "id": "teamId",
+        },
+        "type": "group",
+        "url": "https://converstaionUrl",
+      },
+    },
+    "type": "spaces/STORE_SPACE",
+  },
+]
+`;
+
 exports[`redux-module-space actions  #fetchSpace properly fetches a space 1`] = `
 Array [
   Object {

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.js
@@ -120,8 +120,7 @@ export function fetchSpace(sparkInstance, spaceId) {
   return (dispatch) => sparkInstance.internal.conversation.get({
     id: spaceId
   }, {
-    latestActivity: true,
-    activitiesLimit: 1,
+    activitiesLimit: 25,
     participantAckFilter: `all`,
     includeParticipants: true
   }).then((space) => {
@@ -231,7 +230,7 @@ function storeSpaces(spaces) {
  */
 function constructSpace(space, isDecrypting) {
   const s = {
-    latestActivity: space.activities.items[0],
+    latestActivity: constructLastestActivity(space.activities.items),
     avatar: space.avatar,
     displayName: space.displayName,
     id: space.id,
@@ -251,4 +250,20 @@ function constructSpace(space, isDecrypting) {
   }
 
   return s;
+}
+
+function constructLastestActivity(items) {
+  let latest = items.find((item) => [`tombstone`, `delete`].indexOf(item.verb) === -1);
+  if (!latest) {
+    latest = {
+      actor: {
+        displayName: ``
+      },
+      verb: ``,
+      object: {
+        displayName: ``
+      }
+    };
+  }
+  return latest;
 }

--- a/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-spaces/src/actions.test.js
@@ -177,6 +177,34 @@ describe(`redux-module-space actions `, () => {
         expect(store.getActions()).toMatchSnapshot();
       });
     });
+
+    it(`filters delete messages from a space`, () => {
+      space.activities.items = [
+        {
+          actor: {
+            displayName: ``
+          },
+          verb: `delete`,
+          object: {
+            displayName: ``
+          }
+        },
+        {
+          actor: {
+            displayName: `Marty McFly`
+          },
+          verb: `post`,
+          object: {
+            displayName: `check this out!`
+          }
+        }
+      ];
+      mockSpark.internal.conversation.get = jest.fn(() => Promise.resolve(space));
+      store.dispatch(actions.fetchSpace(mockSpark, `spaceId`)).then(() => {
+        expect(mockSpark.internal.conversation.get).toHaveBeenCalled();
+        expect(store.getActions()).toMatchSnapshot();
+      });
+    });
   });
 
   describe(`#removeSpace`, () => {

--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -232,6 +232,11 @@ export class RecentsWidget extends Component {
 
     let spaceId = activity.target && activity.target.id;
 
+    // On delete, refetch space to get previous activity
+    if (spaceId && [`delete`, `tombstone`].includes(activity.verb)) {
+      props.fetchSpace(sparkInstance, spaceId);
+    }
+
     // Handle spaceId if this is a completely new space or hiding a space
     if (!spaceId && [`create`, `hide`].includes(activity.verb)) {
       spaceId = activity.object.id;


### PR DESCRIPTION
When a delete/tombstone activity arrives, we need to get the last visible activity for that space to display in the preview area. We don't have conversation history downloaded so we need to refresh that space. Since `conversations/{id}` endpoint doesn't support latestActivity filter, we have to do it ourselves.