### PR TITLE
Mark space read improvements

### DIFF
--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import Dropzone from 'react-dropzone';
 import classNames from 'classnames';
-import _ from 'lodash';
+import {debounce, has} from 'lodash';
 import {autobind} from 'core-decorators';
 
 import {
@@ -112,7 +112,11 @@ export class MessageWidget extends Component {
 
   constructor(props) {
     super(props);
-    this.handleScroll = _.debounce(this.handleScroll, 150);
+    this.handleScroll = debounce(this.handleScroll, 150);
+    this.handleMouseMove = debounce(this.handleMouseMove, 500, {
+      leading: true,
+      trailing: false
+    });
   }
 
   componentDidMount() {
@@ -430,12 +434,30 @@ export class MessageWidget extends Component {
       const {
         lastActivity
       } = props;
-      if (_.has(event, 'data.bufferState.conversation') && event.data.bufferState.conversation === 'UNKNOWN') {
+      if (has(event, 'data.bufferState.conversation') && event.data.bufferState.conversation === 'UNKNOWN') {
         // Mercury does not contain enough information about the conversation, refetch
         const sinceDate = lastActivity.published || null;
         props.loadMissingActivities(conversationId, sinceDate, sparkInstance);
       }
     });
+  }
+
+  @autobind
+  acknowledgeLastActivity() {
+    const {
+      props
+    } = this;
+    const {
+      conversation,
+      hasAcknowledgementsDisabled,
+      lastActivity,
+      sparkInstance
+    } = props;
+    if (conversation.get('lastAcknowledgedActivityId') !== lastActivity.id) {
+      if (!hasAcknowledgementsDisabled) {
+        props.acknowledgeActivityOnServer(conversation, lastActivity, sparkInstance);
+      }
+    }
   }
 
   /**
@@ -472,6 +494,15 @@ export class MessageWidget extends Component {
     }
   }
 
+  @autobind
+  handleMouseMove() {
+    const {
+      activityList
+    } = this;
+    if (activityList.isScrolledToBottom()) {
+      this.acknowledgeLastActivity();
+    }
+  }
 
   /**
    * Flag or unflag activity by Id
@@ -589,25 +620,18 @@ export class MessageWidget extends Component {
       activityList
     } = this;
     const {
-      conversation,
       conversationId,
-      isAcknowledgementsDisabled,
       firstActivity,
-      lastActivity,
       sparkInstance,
       widgetMessage
     } = props;
 
     props.setScrollPosition({scrollTop: activityList.getScrollTop()});
 
-    if (activityList.isScrolledToBottom()) {
+    if (activityList.isScrolledToBottom() && document.hasFocus()) {
       props.showScrollToBottomButton(false);
       props.updateHasNewMessage(false);
-      if (conversation.get(`lastAcknowledgedActivityId`) !== lastActivity.id) {
-        if (!isAcknowledgementsDisabled) {
-          props.acknowledgeActivityOnServer(conversation, lastActivity, sparkInstance);
-        }
-      }
+      this.acknowledgeLastActivity();
     }
     else if (!widgetMessage.get('showScrollToBottomButton')) {
       props.showScrollToBottomButton(true);
@@ -655,7 +679,7 @@ export class MessageWidget extends Component {
           disablePreview
           onDrop={this.handleFileDrop}
         >
-          <div className={classNames('ciscospark-widget-message-main-area', styles.mainArea)}>
+          <div className={classNames('ciscospark-widget-message-main-area', styles.mainArea)} onMouseMove={this.handleMouseMove}>
             <div className={classNames('ciscospark-activity-list-wrapper', styles.activityListWrapper)}>
               <ScrollingActivity
                 isLoadingHistoryUp={isLoadingHistoryUp}
@@ -757,7 +781,7 @@ const injectedPropTypes = {
 };
 
 export const ownPropTypes = {
-  isAcknowledgementsDisabled: PropTypes.bool,
+  hasAcknowledgementsDisabled: PropTypes.bool,
   muteNotifications: PropTypes.bool,
   onEvent: PropTypes.func,
   spaceId: PropTypes.string,

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -591,6 +591,7 @@ export class MessageWidget extends Component {
     const {
       conversation,
       conversationId,
+      isAcknowledgementsDisabled,
       firstActivity,
       lastActivity,
       sparkInstance,
@@ -602,8 +603,10 @@ export class MessageWidget extends Component {
     if (activityList.isScrolledToBottom()) {
       props.showScrollToBottomButton(false);
       props.updateHasNewMessage(false);
-      if (conversation.get('lastAcknowledgedActivityId') !== lastActivity.id) {
-        props.acknowledgeActivityOnServer(conversation, lastActivity, sparkInstance);
+      if (conversation.get(`lastAcknowledgedActivityId`) !== lastActivity.id) {
+        if (!isAcknowledgementsDisabled) {
+          props.acknowledgeActivityOnServer(conversation, lastActivity, sparkInstance);
+        }
       }
     }
     else if (!widgetMessage.get('showScrollToBottomButton')) {
@@ -754,6 +757,7 @@ const injectedPropTypes = {
 };
 
 export const ownPropTypes = {
+  isAcknowledgementsDisabled: PropTypes.bool,
   muteNotifications: PropTypes.bool,
   onEvent: PropTypes.func,
   spaceId: PropTypes.string,

--- a/packages/node_modules/@ciscospark/widget-space/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/container.js
@@ -79,6 +79,7 @@ const injectedPropTypes = {
 export const ownPropTypes = {
   customActivityTypes: PropTypes.object,
   initialActivity: PropTypes.string,
+  isAcknowledgementsDisabled: PropTypes.bool,
   muteNotifications: PropTypes.bool,
   spaceId: PropTypes.string,
   startCall: PropTypes.oneOfType([
@@ -93,6 +94,7 @@ export const ownPropTypes = {
 const defaultProps = {
   customActivityTypes: undefined,
   initialActivity: DEFAULT_ACTIVITY,
+  isAcknowledgementsDisabled: false,
   muteNotifications: false,
   spaceId: '',
   startCall: false,

--- a/packages/node_modules/@ciscospark/widget-space/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/container.js
@@ -78,8 +78,8 @@ const injectedPropTypes = {
 
 export const ownPropTypes = {
   customActivityTypes: PropTypes.object,
+  hasAcknowledgementsDisabled: PropTypes.bool,
   initialActivity: PropTypes.string,
-  isAcknowledgementsDisabled: PropTypes.bool,
   muteNotifications: PropTypes.bool,
   spaceId: PropTypes.string,
   startCall: PropTypes.oneOfType([
@@ -93,8 +93,8 @@ export const ownPropTypes = {
 
 const defaultProps = {
   customActivityTypes: undefined,
+  hasAcknowledgementsDisabled: false,
   initialActivity: DEFAULT_ACTIVITY,
-  isAcknowledgementsDisabled: false,
   muteNotifications: false,
   spaceId: '',
   startCall: false,

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -203,6 +203,7 @@ exports.config = {
 
 if (process.env.SAUCE) {
   exports.config = Object.assign(exports.config, {
+    deprecationWarnings: false, // Deprecation warnings on sauce just make the logs noisy
     user: process.env.SAUCE_USERNAME,
     key: process.env.SAUCE_ACCESS_KEY,
     build: process.env.BUILD_NUMBER,


### PR DESCRIPTION
Added a few things that the web client has. 

* If the window isn't active when the new activity arrives, we won't mark it as read. (previously, if it was scrolled to the bottom, it would auto-ack no matter what the status of the widget/window was)
* Moving the mouse while scrolled to the bottom will mark as read