### PR TITLE
Scroll lock behavior

### DIFF
--- a/packages/node_modules/@ciscospark/widget-message/src/actions.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/actions.js
@@ -32,6 +32,44 @@ export function showScrollToBottomButton(isVisible) {
   };
 }
 
+/**
+ * Sets if the widget has been scrolled up from the bottom
+ *
+ * @export
+ * @param {boolean} isScrolledUp
+ * @returns {Thunk}
+ */
+export function setScrolledUp(isScrolledUp) {
+  return (dispatch, getState) => {
+    const {widgetMessage} = getState();
+    // Since we are triggering this every scroll, let's not attack
+    // our store if we don't need to
+    if (!isScrolledUp) {
+      /* eslint-disable operator-linebreak */
+      if (
+        widgetMessage.get('hasNewMessage') ||
+        widgetMessage.get('hasScrolledUp') ||
+        widgetMessage.get('showScrollToBottomButton')
+      ) {
+        dispatch(updateWidgetState({
+          hasNewMessage: false,
+          hasScrolledUp: false,
+          showScrollToBottomButton: false
+        }));
+      }
+    }
+    /* eslint-disable operator-linebreak */
+    else if (
+      !widgetMessage.get('hasScrolledUp') ||
+      !widgetMessage.get('showScrollToBottomButton')
+    ) {
+      dispatch(updateWidgetState({
+        hasScrolledUp: true,
+        showScrollToBottomButton: true
+      }));
+    }
+  };
+}
 
 export function updateHasNewMessage(hasNew) {
   return (dispatch) => {

--- a/packages/node_modules/@ciscospark/widget-message/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-message/src/container.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import Dropzone from 'react-dropzone';
 import classNames from 'classnames';
-import {debounce, has} from 'lodash';
+import {debounce, has, throttle} from 'lodash';
 import {autobind} from 'core-decorators';
 
 import {
@@ -68,6 +68,7 @@ import {
   confirmDeleteActivity,
   deleteActivityAndDismiss,
   hideDeleteModal,
+  setScrolledUp,
   setScrollPosition,
   showScrollToBottomButton,
   updateHasNewMessage,
@@ -109,9 +110,34 @@ export class MessageWidget extends Component {
     props.fetchAvatarsForUsers(userIds, sparkInstance);
   }
 
+  /**
+   * Check if activity list should scroll to bottom
+   *
+   * @param {object} props
+   * @param {object} prevProps
+   * @returns {boolean}
+   */
+  static shouldScrollToBottom(props, prevProps) {
+    const {
+      activityCount
+    } = props;
+    const prevActivitiesCount = prevProps.activityCount;
+    if (activityCount && prevActivitiesCount === 0) {
+      // Always scroll to the bottom when activities first load
+      return true;
+    }
+
+    // Otherwise, don't scroll if we have scrolled up
+    let shouldScrollToBottom = true;
+    if (props.widgetMessage.get('hasScrolledUp')) {
+      shouldScrollToBottom = false;
+    }
+    return shouldScrollToBottom;
+  }
+
   constructor(props) {
     super(props);
-    this.handleScroll = debounce(this.handleScroll, 150);
+    this.handleScroll = throttle(this.handleScroll, 250);
     this.handleMouseMove = debounce(this.handleMouseMove, 500, {
       leading: true,
       trailing: false
@@ -185,7 +211,8 @@ export class MessageWidget extends Component {
         props.createNotification(lastActivityFromThis.url, NOTIFICATION_TYPE_POST);
       }
       this.updateScroll(firstActivity, previousFirstActivity, prevProps.widgetMessage.get('scrollPosition').scrollTop);
-      if (this.shouldScrollToBottom(props, prevProps)) {
+
+      if (MessageWidget.shouldScrollToBottom(props, prevProps)) {
         activityList.scrollToBottom();
       }
     }
@@ -319,43 +346,6 @@ export class MessageWidget extends Component {
     if (conversationId) {
       this.setupConversationActions(conversation, props);
     }
-  }
-
-
-  /**
-   * Check if activity list should scroll to bottom
-   *
-   * @param {object} props
-   * @param {object} prevProps
-   * @returns {boolean}
-   */
-  shouldScrollToBottom(props, prevProps) {
-    let shouldScrollToBottom = false;
-    const {activityList} = this;
-    const lastActivityFromPrev = prevProps.lastActivity;
-    const lastActivityFromThis = props.lastActivity;
-    // If new activity comes in
-    if (lastActivityFromPrev
-      && lastActivityFromThis
-      && props.activityCount !== prevProps.activityCount
-      && lastActivityFromPrev.id !== lastActivityFromThis.id) {
-      // Scroll if from ourselves
-      if (props.user.get('currentUser').id === lastActivityFromThis.actor.id) {
-        shouldScrollToBottom = true;
-      }
-      else if (activityList.isScrolledToBottom()) {
-        shouldScrollToBottom = true;
-      }
-    }
-    else if (prevProps.activityCount === 0) {
-      shouldScrollToBottom = true;
-    }
-    // Scroll to show in flight activities
-    if (props.activity.get('inFlightActivities').size && props.activity.get('inFlightActivities').size !== prevProps.activity.get('inFlightActivities').size) {
-      shouldScrollToBottom = true;
-    }
-
-    return shouldScrollToBottom;
   }
 
   /**
@@ -608,22 +598,23 @@ export class MessageWidget extends Component {
     const {
       conversationId,
       firstActivity,
-      sparkInstance,
-      widgetMessage
+      sparkInstance
     } = props;
 
-    props.setScrollPosition({scrollTop: activityList.getScrollTop()});
-
-    if (activityList.isScrolledToBottom() && document.hasFocus()) {
-      props.showScrollToBottomButton(false);
-      props.updateHasNewMessage(false);
-      this.acknowledgeLastActivity();
+    if (activityList.isScrolledToBottom()) {
+      props.setScrolledUp(false);
+      if (document.hasFocus()) {
+        this.acknowledgeLastActivity();
+      }
     }
-    else if (!widgetMessage.get('showScrollToBottomButton')) {
-      props.showScrollToBottomButton(true);
+    else {
+      props.setScrolledUp(true);
     }
 
     if (activityList.isScrolledToTop() && firstActivity.verb !== 'create') {
+      // Store scroll position before loading messages so the window
+      // doesn't jump after they load
+      props.setScrollPosition({scrollTop: activityList.getScrollTop()});
       props.loadPreviousMessages(
         conversationId,
         firstActivity.published,
@@ -754,6 +745,7 @@ const injectedPropTypes = {
   retryFailedActivity: PropTypes.func.isRequired,
   removeInflightActivity: PropTypes.func.isRequired,
   setScrollPosition: PropTypes.func.isRequired,
+  setScrolledUp: PropTypes.func.isRequired,
   setTyping: PropTypes.func.isRequired,
   showScrollToBottomButton: PropTypes.func.isRequired,
   updateHasNewMessage: PropTypes.func.isRequired,
@@ -803,6 +795,7 @@ export default connect(
     removeInflightActivity,
     retryFailedActivity,
     setScrollPosition,
+    setScrolledUp,
     setTyping,
     showScrollToBottomButton,
     subscribeToPresenceUpdates,


### PR DESCRIPTION
Should follow this:
## Scrolling

* Lock scroll to bottom on initial load
* Scroll locks to the bottom unless user scrolls up
* once the user scrolls to bottom, it locks again

## Read

* activity is marked read when window has focus and is scrolled to the bottom
* if list manually scrolls to the bottom, mark as read even if not in focus (can scroll out of focus on mac)
  