### PR TITLE
Media Module: Call objects as Records

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/actions.test.js.snap
@@ -211,6 +211,17 @@ Array [
 ]
 `;
 
+exports[`redux-module-media actions  #dismissIncomingCall can successfully dismiss an incoming call 1`] = `
+Array [
+  Object {
+    "payload": Object {
+      "callId": "abc-123",
+    },
+    "type": "media/DISMISS_INCOMING_CALL",
+  },
+]
+`;
+
 exports[`redux-module-media actions  #hangupCall can successfully hangup active call 1`] = `
 Array [
   Object {
@@ -344,7 +355,8 @@ Array [
         "sendingVideo": "",
         "state": undefined,
       },
-      "locusUrl": undefined,
+      "isIncoming": true,
+      "locusUrl": "https://locusUrl",
     },
     "type": "media/STORE_CALL",
   },
@@ -491,6 +503,7 @@ Array [
         "sendingVideo": "",
         "state": undefined,
       },
+      "isIncoming": false,
       "locusUrl": "https://locusUrl",
     },
     "type": "media/STORE_CALL",
@@ -507,4 +520,25 @@ Array [
     "type": "media/UPDATE_WEBRTC_SUPPORT",
   },
 ]
+`;
+
+exports[`redux-module-media actions  has exported actions 1`] = `
+Object {
+  "CHECKING_WEB_RTC_SUPPORT": "media/CHECKING_WEB_RTC_SUPPORT",
+  "CONNECT_CALL": "media/CONNECT_CALL",
+  "DISMISS_INCOMING_CALL": "media/DISMISS_INCOMING_CALL",
+  "REMOVE_CALL": "media/REMOVE_CALL",
+  "STORE_CALL": "media/STORE_CALL",
+  "UPDATE_CALL_STATE": "media/UPDATE_CALL_STATE",
+  "UPDATE_STATUS": "media/UPDATE_STATUS",
+  "UPDATE_WEBRTC_SUPPORT": "media/UPDATE_WEBRTC_SUPPORT",
+  "acceptIncomingCall": [Function],
+  "checkWebRTCSupport": [Function],
+  "declineIncomingCall": [Function],
+  "dismissIncomingCall": [Function],
+  "hangupCall": [Function],
+  "listenForIncomingCalls": [Function],
+  "placeCall": [Function],
+  "updateWebRTCSupport": [Function],
+}
 `;

--- a/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/reducer.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/reducer.test.js.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`redux-module-media reducer should handle CHECKING_WEB_RTC_SUPPORT 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {},
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": true,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;
+
+exports[`redux-module-media reducer should handle CONNECT_CALL 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {
+    "http://abc-123.gov": Immutable.Record {
+      "id": "http://abc-123.gov",
+      "instance": Object {
+        "connected": true,
+        "locus": Object {
+          "fullState": Object {
+            "lastActive": 1515449380157,
+          },
+          "url": "http://abc-123.gov",
+        },
+        "mock": true,
+      },
+      "spaceId": null,
+      "callState": Object {
+        "connected": true,
+        "mockState": true,
+      },
+      "callStartTime": NaN,
+    },
+  },
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;
+
+exports[`redux-module-media reducer should handle REMOVE_CALL 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {},
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;
+
+exports[`redux-module-media reducer should handle STORE_CALL 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {
+    "http://abc-123.gov": Immutable.Record {
+      "id": "http://abc-123.gov",
+      "instance": Object {
+        "mock": true,
+      },
+      "spaceId": null,
+      "callState": Object {
+        "mockState": true,
+      },
+      "callStartTime": null,
+    },
+  },
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;
+
+exports[`redux-module-media reducer should handle UPDATE_CALL_STATE 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {
+    "http://abc-123.gov": Immutable.Record {
+      "id": "http://abc-123.gov",
+      "instance": null,
+      "spaceId": null,
+      "callState": Object {
+        "mockState": true,
+        "updated": true,
+      },
+      "callStartTime": null,
+    },
+  },
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;
+
+exports[`redux-module-media reducer should handle UPDATE_STATUS 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {},
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": true,
+  },
+}
+`;
+
+exports[`redux-module-media reducer should handle UPDATE_WEBRTC_SUPPORT 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {},
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": true,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;
+
+exports[`redux-module-media reducer should return an initial state 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {},
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;

--- a/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/reducer.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/reducer.test.js.snap
@@ -28,12 +28,37 @@ Immutable.Map {
         },
         "mock": true,
       },
+      "isDismissed": false,
+      "isIncoming": false,
       "spaceId": null,
       "callState": Object {
         "connected": true,
         "mockState": true,
       },
       "callStartTime": NaN,
+    },
+  },
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;
+
+exports[`redux-module-media reducer should handle DISMISS_INCOMING_CALL 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {
+    "http://abc-123.gov": Immutable.Record {
+      "id": "http://abc-123.gov",
+      "instance": null,
+      "isDismissed": true,
+      "isIncoming": true,
+      "spaceId": null,
+      "callState": Object {},
+      "callStartTime": null,
     },
   },
   "webRTC": Immutable.Map {
@@ -67,6 +92,8 @@ Immutable.Map {
       "instance": Object {
         "mock": true,
       },
+      "isDismissed": false,
+      "isIncoming": undefined,
       "spaceId": null,
       "callState": Object {
         "mockState": true,
@@ -90,6 +117,8 @@ Immutable.Map {
     "http://abc-123.gov": Immutable.Record {
       "id": "http://abc-123.gov",
       "instance": null,
+      "isDismissed": false,
+      "isIncoming": false,
       "spaceId": null,
       "callState": Object {
         "mockState": true,

--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
@@ -3,10 +3,13 @@ import {
 } from './helpers';
 
 export const UPDATE_STATUS = 'media/UPDATE_STATUS';
+
+export const DISMISS_INCOMING_CALL = 'media/DISMISS_INCOMING_CALL';
 export const STORE_CALL = 'media/STORE_CALL';
-export const UPDATE_CALL_STATE = 'media/UPDATE_CALL_STATE';
 export const CONNECT_CALL = 'media/CONNECT_CALL';
 export const REMOVE_CALL = 'media/REMOVE_CALL';
+export const UPDATE_CALL_STATE = 'media/UPDATE_CALL_STATE';
+
 export const CHECKING_WEB_RTC_SUPPORT = 'media/CHECKING_WEB_RTC_SUPPORT';
 export const UPDATE_WEBRTC_SUPPORT = 'media/UPDATE_WEBRTC_SUPPORT';
 
@@ -33,12 +36,13 @@ function updateStatus(status) {
 }
 
 
-function storeCall(call, locusUrl) {
+function storeCall(call, locusUrl, isIncoming = false) {
   return {
     type: STORE_CALL,
     payload: {
       call,
       callState: constructCallState(call),
+      isIncoming,
       locusUrl
     }
   };
@@ -83,6 +87,20 @@ export function updateWebRTCSupport(supported) {
   };
 }
 
+/**
+ * Dismisses an incoming call, marking it so.
+ * Note: This does not decline the call, just for tracking purposes
+ * @param {string} callId
+ * @returns {object}
+ */
+export function dismissIncomingCall(callId) {
+  return {
+    type: DISMISS_INCOMING_CALL,
+    payload: {
+      callId
+    }
+  };
+}
 
 export function hangupCall({call, locusUrl}) {
   return (dispatch) => {
@@ -184,7 +202,7 @@ export function listenForIncomingCalls(sparkInstance, locusUrl) {
 
       return incomingCall.acknowledge()
         .then(() => {
-          const removeIncoming = () => dispatch(removeCall(incomingCall));
+          const removeIncoming = () => dispatch(removeCall(incomingCall, incomingCall.locus.url));
 
           // If the remote party hangs up before we accept/decline
           incomingCall.once('inactive', removeIncoming);
@@ -195,7 +213,7 @@ export function listenForIncomingCalls(sparkInstance, locusUrl) {
               incomingCall.off('inactive', removeIncoming);
             }
           });
-          return dispatch(storeCall(incomingCall));
+          return dispatch(storeCall(incomingCall, incomingCall.locus.url, true));
         });
     });
   };
@@ -216,6 +234,12 @@ export function declineIncomingCall(incomingCall) {
   };
 }
 
+/**
+ * Answers a call object
+ * @param {object} incomingCall
+ * @param {string} locusUrl
+ * @returns {Promise}
+ */
 export function acceptIncomingCall(incomingCall, locusUrl) {
   return (dispatch) =>
     incomingCall.answer({offerOptions: {offerToReceiveVideo: true, offerToReceiveAudio: true}})
@@ -224,7 +248,6 @@ export function acceptIncomingCall(incomingCall, locusUrl) {
         return dispatch(connectCall(incomingCall));
       });
 }
-
 
 /**
  * Check for browser webRTC support

--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.test.js
@@ -50,13 +50,7 @@ describe('redux-module-media actions ', () => {
   });
 
   it('has exported actions', () => {
-    expect(actions.updateWebRTCSupport).toBeDefined();
-    expect(actions.placeCall).toBeDefined();
-    expect(actions.hangupCall).toBeDefined();
-    expect(actions.listenForIncomingCalls).toBeDefined();
-    expect(actions.declineIncomingCall).toBeDefined();
-    expect(actions.acceptIncomingCall).toBeDefined();
-    expect(actions.checkWebRTCSupport).toBeDefined();
+    expect(actions).toMatchSnapshot();
   });
 
 
@@ -146,5 +140,12 @@ describe('redux-module-media actions ', () => {
           expect(call.answer).toHaveBeenCalled();
           expect(store.getActions()).toMatchSnapshot();
         }));
+  });
+
+  describe('#dismissIncomingCall', () => {
+    it('can successfully dismiss an incoming call', () => {
+      store.dispatch(actions.dismissIncomingCall('abc-123'));
+      expect(store.getActions()).toMatchSnapshot();
+    });
   });
 });

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
@@ -1,4 +1,4 @@
-import {fromJS} from 'immutable';
+import {fromJS, Record} from 'immutable';
 
 import {
   UPDATE_STATUS,
@@ -10,11 +10,12 @@ import {
   UPDATE_WEBRTC_SUPPORT
 } from './actions';
 
-const initialCallObject = fromJS({
+export const CallRecord = new Record({
+  id: null,
   instance: null,
   spaceId: null,
   callState: {},
-  startTime: null
+  callStartTime: null
 });
 
 export const initialState = fromJS({
@@ -37,10 +38,12 @@ export default function reducer(state = initialState, action) {
       const {call, callState, locusUrl} = action.payload;
       const id = locusUrl || call.locus && call.locus.url;
       if (id) {
-        const callObject = initialCallObject
-          .set('instance', call)
-          .mergeIn(['callState'], callState);
-        return state.setIn(['calls', id], callObject);
+        const callRecord = new CallRecord({
+          callState,
+          id,
+          instance: call
+        });
+        return state.setIn(['calls', id], callRecord);
       }
       return state;
     }
@@ -67,8 +70,7 @@ export default function reducer(state = initialState, action) {
     }
 
     case REMOVE_CALL: {
-      const {locus} = action.payload.call;
-      const locusUrl = action.payload.locusUrl || locus.url;
+      const locusUrl = action.payload.locusUrl || action.payload.locus.url;
       if (locusUrl) {
         return state.deleteIn(['calls', locusUrl]);
       }

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
@@ -1,6 +1,7 @@
 import {fromJS, Record} from 'immutable';
 
 import {
+  DISMISS_INCOMING_CALL,
   UPDATE_STATUS,
   UPDATE_CALL_STATE,
   CONNECT_CALL,
@@ -13,6 +14,8 @@ import {
 export const CallRecord = new Record({
   id: null,
   instance: null,
+  isDismissed: false,
+  isIncoming: false,
   spaceId: null,
   callState: {},
   callStartTime: null
@@ -35,13 +38,19 @@ export default function reducer(state = initialState, action) {
       return state.mergeIn(['status'], action.payload.status);
 
     case STORE_CALL: {
-      const {call, callState, locusUrl} = action.payload;
+      const {
+        call,
+        callState,
+        isIncoming,
+        locusUrl
+      } = action.payload;
       const id = locusUrl || call.locus && call.locus.url;
       if (id) {
         const callRecord = new CallRecord({
           callState,
           id,
-          instance: call
+          instance: call,
+          isIncoming
         });
         return state.setIn(['calls', id], callRecord);
       }
@@ -70,11 +79,15 @@ export default function reducer(state = initialState, action) {
     }
 
     case REMOVE_CALL: {
-      const locusUrl = action.payload.locusUrl || action.payload.locus.url;
+      const locusUrl = action.payload.locusUrl || action.payload.call.locus.url;
       if (locusUrl) {
         return state.deleteIn(['calls', locusUrl]);
       }
       return state;
+    }
+
+    case DISMISS_INCOMING_CALL: {
+      return state.setIn(['calls', action.payload.callId, 'isDismissed'], true);
     }
 
     case CHECKING_WEB_RTC_SUPPORT:

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.test.js
@@ -1,5 +1,6 @@
 import reducer, {initialState, CallRecord} from './reducer';
 import {
+  DISMISS_INCOMING_CALL,
   CHECKING_WEB_RTC_SUPPORT,
   CONNECT_CALL,
   REMOVE_CALL,
@@ -107,6 +108,19 @@ describe('redux-module-media reducer', () => {
       type: REMOVE_CALL,
       payload: {
         locusUrl: url
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle DISMISS_INCOMING_CALL', () => {
+    const id = 'http://abc-123.gov';
+    const callRecord = new CallRecord({id, isIncoming: true});
+    const updatedState = initialState.setIn(['calls', id], callRecord);
+
+    expect(reducer(updatedState, {
+      type: DISMISS_INCOMING_CALL,
+      payload: {
+        callId: id
       }
     })).toMatchSnapshot();
   });

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.test.js
@@ -1,0 +1,113 @@
+import reducer, {initialState, CallRecord} from './reducer';
+import {
+  CHECKING_WEB_RTC_SUPPORT,
+  CONNECT_CALL,
+  REMOVE_CALL,
+  STORE_CALL,
+  UPDATE_CALL_STATE,
+  UPDATE_STATUS,
+  UPDATE_WEBRTC_SUPPORT
+} from './actions';
+
+describe('redux-module-media reducer', () => {
+  it('should return an initial state', () => {
+    expect(reducer(undefined, {}))
+      .toMatchSnapshot();
+  });
+
+  it('should handle CHECKING_WEB_RTC_SUPPORT', () => {
+    expect(reducer(initialState, {
+      type: CHECKING_WEB_RTC_SUPPORT
+    })).toMatchSnapshot();
+  });
+
+  it('should handle UPDATE_WEBRTC_SUPPORT', () => {
+    expect(reducer(initialState, {
+      type: UPDATE_WEBRTC_SUPPORT,
+      payload: {
+        supported: true
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle UPDATE_STATUS', () => {
+    expect(reducer(initialState, {
+      type: UPDATE_STATUS,
+      payload: {
+        status: {
+          isListening: true
+        }
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle STORE_CALL', () => {
+    expect(reducer(initialState, {
+      type: STORE_CALL,
+      payload: {
+        call: {
+          mock: true
+        },
+        callState: {
+          mockState: true
+        },
+        locusUrl: 'http://abc-123.gov'
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle UPDATE_CALL_STATE', () => {
+    const url = 'http://abc-123.gov';
+    const callRecord = new CallRecord({id: url});
+    const updatedState = initialState.setIn(['calls', url], callRecord);
+    expect(reducer(updatedState, {
+      type: UPDATE_CALL_STATE,
+      payload: {
+        callState: {
+          mockState: true,
+          updated: true
+        },
+        locusUrl: url
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle CONNECT_CALL', () => {
+    const url = 'http://abc-123.gov';
+    const callRecord = new CallRecord({id: url});
+    const updatedState = initialState.setIn(['calls', url], callRecord);
+
+    expect(reducer(updatedState, {
+      type: CONNECT_CALL,
+      payload: {
+        call: {
+          locus: {
+            fullState: {
+              lastActive: 1515449380157
+            },
+            url
+          },
+          mock: true,
+          connected: true
+        },
+        callState: {
+          mockState: true,
+          connected: true
+        }
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle REMOVE_CALL', () => {
+    const url = 'http://abc-123.gov';
+    const callRecord = new CallRecord({id: url});
+    const updatedState = initialState.setIn(['calls', url], callRecord);
+
+    expect(reducer(updatedState, {
+      type: REMOVE_CALL,
+      payload: {
+        locusUrl: url
+      }
+    })).toMatchSnapshot();
+  });
+});

--- a/packages/node_modules/@ciscospark/widget-meet/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-meet/src/selector.js
@@ -75,8 +75,8 @@ const getMeetWidgetProps = createSelector(
 
     let callFrom, callInstance, callIsActive, callIsIncoming, callIsRinging, callState;
     if (call) {
-      callState = call.get('callState').toJS();
-      callInstance = call.get('instance');
+      ({callState, instance: callInstance} = call);
+
       // Is the call active?
       const {
         direction,
@@ -85,7 +85,7 @@ const getMeetWidgetProps = createSelector(
         joinedOnThisDevice,
         isCall,
         isInitiated
-      } = callState;
+      } = call.callState;
 
       callIsRinging = ringing;
       callIsActive = connected && joinedOnThisDevice || direction === 'out';

--- a/packages/node_modules/@ciscospark/widget-recents/src/actions.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/actions.js
@@ -1,7 +1,4 @@
 export const UPDATE_STATUS = 'widget-recents/UPDATE_STATUS';
-export const STORE_INCOMING_CALL = 'widget-recents/STORE_INCOMING_CALL';
-export const DELETE_INCOMING_CALL = 'widget-recents/DELETE_INCOMING_CALL';
-export const UPDATE_WEBRTC_SUPPORT = 'widget-recents/UPDATE_WEBRTC_SUPPORT';
 export const UPDATE_VISIBILITY_COUNT = 'widget-recents/UPDATE_VISIBILITY_COUNT';
 
 
@@ -10,30 +7,6 @@ export function updateWidgetStatus(status) {
     type: UPDATE_STATUS,
     payload: {
       status
-    }
-  };
-}
-
-export function storeIncomingCall(call) {
-  return {
-    type: STORE_INCOMING_CALL,
-    payload: {
-      call
-    }
-  };
-}
-
-export function deleteIncomingCall() {
-  return {
-    type: DELETE_INCOMING_CALL
-  };
-}
-
-export function updateWebRTCSupport(support) {
-  return {
-    type: UPDATE_WEBRTC_SUPPORT,
-    payload: {
-      support
     }
   };
 }

--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -4,10 +4,15 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import classNames from 'classnames';
 import {autobind} from 'core-decorators';
-import LoadingScreen from '@ciscospark/react-component-loading-screen';
-import Spinner from '@ciscospark/react-component-spinner';
-import ErrorDisplay from '@ciscospark/react-component-error-display';
+
+import {fetchAvatar} from '@ciscospark/redux-module-avatar';
 import {addError, removeError} from '@ciscospark/redux-module-errors';
+import {
+  getFeature,
+  FEATURE_GROUP_CALLING
+} from '@ciscospark/redux-module-features';
+import {declineIncomingCall, dismissIncomingCall, listenForIncomingCalls} from '@ciscospark/redux-module-media';
+import {connectToMercury} from '@ciscospark/redux-module-mercury';
 import {
   acknowledgeSpace,
   fetchSpace,
@@ -17,23 +22,18 @@ import {
   updateSpaceWithActivity,
   updateSpaceRead
 } from '@ciscospark/redux-module-spaces';
-import {fetchAvatar} from '@ciscospark/redux-module-avatar';
-import {fetchTeams} from '@ciscospark/redux-module-teams';
 import {events as metricEvents} from '@ciscospark/react-redux-spark-metrics';
-import {connectToMercury} from '@ciscospark/redux-module-mercury';
-import {
-  getFeature,
-  FEATURE_GROUP_CALLING
-} from '@ciscospark/redux-module-features';
+import {fetchTeams} from '@ciscospark/redux-module-teams';
+
+import LoadingScreen from '@ciscospark/react-component-loading-screen';
+import Spinner from '@ciscospark/react-component-spinner';
+import ErrorDisplay from '@ciscospark/react-component-error-display';
 import IncomingCall from '@ciscospark/react-component-incoming-call';
 
 import messages from './messages';
 import getRecentsWidgetProps from './selector';
 import {
   updateWidgetStatus,
-  updateWebRTCSupport,
-  storeIncomingCall,
-  deleteIncomingCall,
   updateVisibilityCount
 } from './actions';
 import SpacesList from './components/spaces-list';
@@ -51,6 +51,8 @@ const injectedPropTypes = {
   hasGroupCalling: PropTypes.bool,
   errors: PropTypes.object,
   eventNames: PropTypes.object,
+  incomingCall: PropTypes.object,
+  media: PropTypes.object,
   mercury: PropTypes.object,
   metrics: PropTypes.object,
   spaces: PropTypes.object,
@@ -62,7 +64,10 @@ const injectedPropTypes = {
   widgetStatus: PropTypes.object,
   addError: PropTypes.func,
   connectToMercury: PropTypes.func,
+  dismissIncomingCall: PropTypes.func.isRequired,
+  declineIncomingCall: PropTypes.func.isRequired,
   fetchAvatar: PropTypes.func,
+  listenForIncomingCalls: PropTypes.func.isRequired,
   removeError: PropTypes.func,
   updateWidgetStatus: PropTypes.func
 };
@@ -79,11 +84,11 @@ export class RecentsWidget extends Component {
       spark,
       sparkInstance,
       sparkState,
+      media,
       mercury,
       metrics,
       spaces,
-      teams,
-      widgetStatus
+      teams
     } = props;
 
     // Check for spark device errors (auth)
@@ -134,11 +139,8 @@ export class RecentsWidget extends Component {
         }
       }
 
-      if (sparkInstance && sparkInstance.phone && !widgetStatus.hasCheckedWebRTCSupport) {
-        props.updateWidgetStatus({hasCheckedWebRTCSupport: true});
-        sparkInstance.phone.isCallingSupported().then((supported) => {
-          props.updateWebRTCSupport(supported);
-        });
+      if (!media.getIn(['status', 'isListening'])) {
+        props.listenForIncomingCalls(sparkInstance);
       }
     }
     if (spaces.getIn(['status', 'hasFetched'])) {
@@ -197,12 +199,13 @@ export class RecentsWidget extends Component {
     return nextProps.spacesList !== this.props.spacesList
       || nextProps.mercury !== this.props.mercury
       || nextProps.errors !== this.props.errors
-      || nextProps.widgetRecents !== this.props.widgetRecents;
+      || nextProps.widgetRecents !== this.props.widgetRecents
+      || nextProps.incomingCall !== this.props.incomingCall;
   }
 
   @autobind
   getSpaceFromCall(call) {
-    return this.props.spacesList.get(call.locus.conversationUrl.split('/').pop());
+    return this.props.spacesList.get(call.instance.locus.conversationUrl.split('/').pop());
   }
 
   @autobind
@@ -244,6 +247,7 @@ export class RecentsWidget extends Component {
   addListeners(nextProps) {
     const {
       currentUser,
+      incomingCall,
       spaces,
       sparkInstance,
       widgetStatus
@@ -254,7 +258,10 @@ export class RecentsWidget extends Component {
       && !widgetStatus.isListeningForNewActivity
     ) {
       this.listenForNewActivity(sparkInstance, nextProps);
-      this.listenForCall(sparkInstance, nextProps);
+    }
+    if (incomingCall && !this.props.incomingCall) {
+      const space = this.getSpaceFromCall(incomingCall);
+      this.handleEvent(eventNames.CALLS_CREATED, constructCallEventData(incomingCall.instance, space));
     }
   }
 
@@ -383,64 +390,14 @@ export class RecentsWidget extends Component {
     return sparkInstance.internal.mercury.on('event:conversation.activity', (event) => this.handleNewActivity(event.data.activity));
   }
 
-  /**
-   * Setup listeners for call activities
-   *
-   * @param {Object} sparkInstance
-   * @param {Object} props
-   * @returns {Promise}
-   */
-  listenForCall(sparkInstance, props) {
-    props.updateWidgetStatus({isListeningForCall: true});
-    return sparkInstance.phone.on('call:incoming', (call) => this.handleCall(call));
-  }
-
-
-  @autobind
-  handleCall(call) {
-    const {
-      props,
-      handleEvent
-    } = this;
-    const {
-      hasGroupCalling,
-      spacesList
-    } = props;
-
-    const space = spacesList.get(call.locus.conversationUrl.split('/').pop());
-    // Only provide event if the call is direct
-    if (hasGroupCalling || space.type === 'direct') {
-      call.acknowledge()
-        .then(() => {
-          const removeIncoming = () => call.hangup().then(props.deleteIncomingCall);
-
-          // If call signals inactive we fire hangup and clean up
-          call.once('inactive', removeIncoming);
-
-          // If call signals connected we clean up
-          const checkForConnected = () => {
-            if (call.me.state === 'connected') {
-              call.off('membership:change', checkForConnected);
-              call.off('inactive', removeIncoming);
-              props.deleteIncomingCall();
-            }
-          };
-          call.on('membership:change', checkForConnected);
-
-          props.storeIncomingCall(call);
-          handleEvent(eventNames.CALLS_CREATED, constructCallEventData(call, space));
-        });
-    }
-  }
-
   @autobind
   handleAnswer() {
-    const space = this.getSpaceFromCall(this.props.widgetRecents.get('incomingCall'));
+    const space = this.getSpaceFromCall(this.props.incomingCall);
     this.handleEvent(eventNames.SPACES_SELECTED, {
       action: eventNames.ACTION_CALL_ANSWER,
       ...constructRoomsEventData(space)
     });
-    this.props.deleteIncomingCall();
+    this.props.dismissIncomingCall(this.props.incomingCall.instance.locus.url);
   }
 
   @autobind
@@ -450,17 +407,13 @@ export class RecentsWidget extends Component {
       getSpaceFromCall,
       handleEvent
     } = this;
-    const call = props.widgetRecents.get('incomingCall');
-    const space = getSpaceFromCall(call);
+    const space = getSpaceFromCall(props.incomingCall);
 
-    call.reject()
-      .then(() => {
-        handleEvent(eventNames.SPACES_SELECTED, {
-          action: eventNames.ACTION_CALL_REJECT,
-          ...constructRoomsEventData(space)
-        });
-        props.deleteIncomingCall();
-      });
+    props.declineIncomingCall(props.incomingCall.instance);
+    handleEvent(eventNames.SPACES_SELECTED, {
+      action: eventNames.ACTION_CALL_REJECT,
+      ...constructRoomsEventData(space)
+    });
   }
 
   @autobind
@@ -509,11 +462,11 @@ export class RecentsWidget extends Component {
     const {
       errors,
       hasGroupCalling,
+      incomingCall,
       spacesList,
       spaces,
       currentUser,
-      widgetRecents,
-      widgetStatus
+      widgetRecents
     } = props;
     const {formatMessage} = props.intl;
     const isFetchingSpaces = spaces.getIn(['status', 'isFetching']);
@@ -524,8 +477,6 @@ export class RecentsWidget extends Component {
     const showLoader = isFetchingSpaces && isShowingMoreSpaces;
     const showMoreButton = (isFetchingSpaces || hasMoreSpaces) && !isShowingMoreSpaces;
 
-    const incomingCall = widgetRecents.get('incomingCall');
-    const {hasWebRTCSupport} = widgetStatus;
     let displaySubtitle, displayTitle, temporary, widgetError;
     if (errors.get('hasError')) {
       widgetError = errors.get('errors').first();
@@ -537,8 +488,8 @@ export class RecentsWidget extends Component {
     }
 
     if (spacesList && hasFetchedSpaces) {
-      if (incomingCall && hasWebRTCSupport) {
-        const space = spacesList.get(incomingCall.locus.conversationUrl.split('/').pop());
+      if (incomingCall) {
+        const space = this.getSpaceFromCall(incomingCall);
         return (
           <div className={classNames('ciscospark-recents-widget', styles.recentsWidget)}>
             <IncomingCall
@@ -553,7 +504,6 @@ export class RecentsWidget extends Component {
           </div>
         );
       }
-      const handleCallClick = hasWebRTCSupport ? this.handleSpaceCallClick : undefined;
       return (
         <div className={classNames('ciscospark-recents-widget', styles.recentsWidget)}>
           {
@@ -571,7 +521,7 @@ export class RecentsWidget extends Component {
               currentUser={currentUser}
               formatMessage={formatMessage}
               hasGroupCalling={hasGroupCalling}
-              onCallClick={handleCallClick}
+              onCallClick={this.handleSpaceCallClick}
               onClick={this.handleSpaceClick}
               spaces={spacesList}
             />
@@ -625,20 +575,20 @@ export default connect(
     acknowledgeSpace,
     addError,
     connectToMercury,
-    deleteIncomingCall,
+    declineIncomingCall,
+    dismissIncomingCall,
     fetchAvatar,
     fetchSpace,
     fetchSpaces,
     fetchTeams,
     getFeature,
     hideSpace,
+    listenForIncomingCalls,
     removeError,
     removeSpace,
-    storeIncomingCall,
     updateSpaceRead,
     updateSpaceWithActivity,
     updateVisibilityCount,
-    updateWebRTCSupport,
     updateWidgetStatus
   }, dispatch)
 )(RecentsWidget);

--- a/packages/node_modules/@ciscospark/widget-recents/src/container.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/container.js
@@ -11,7 +11,7 @@ import {
   getFeature,
   FEATURE_GROUP_CALLING
 } from '@ciscospark/redux-module-features';
-import {declineIncomingCall, dismissIncomingCall, listenForIncomingCalls} from '@ciscospark/redux-module-media';
+import {checkWebRTCSupport, declineIncomingCall, dismissIncomingCall, listenForIncomingCalls} from '@ciscospark/redux-module-media';
 import {connectToMercury} from '@ciscospark/redux-module-mercury';
 import {
   acknowledgeSpace,
@@ -63,6 +63,7 @@ const injectedPropTypes = {
   widgetRecents: PropTypes.object,
   widgetStatus: PropTypes.object,
   addError: PropTypes.func,
+  checkWebRTCSupport: PropTypes.func.isRequired,
   connectToMercury: PropTypes.func,
   dismissIncomingCall: PropTypes.func.isRequired,
   declineIncomingCall: PropTypes.func.isRequired,
@@ -139,7 +140,14 @@ export class RecentsWidget extends Component {
         }
       }
 
-      if (!media.getIn(['status', 'isListening'])) {
+      // Listen for incoming calls
+      const hasCheckedWebRTCSupport = media.getIn(['webRTC', 'hasCheckedSupport']);
+      const isWebRTCSupported = media.getIn(['webRTC', 'isSupported']);
+
+      if (!hasCheckedWebRTCSupport) {
+        props.checkWebRTCSupport(sparkInstance);
+      }
+      if (isWebRTCSupported && !media.getIn(['status', 'isListening'])) {
         props.listenForIncomingCalls(sparkInstance);
       }
     }
@@ -463,6 +471,7 @@ export class RecentsWidget extends Component {
       errors,
       hasGroupCalling,
       incomingCall,
+      media,
       spacesList,
       spaces,
       currentUser,
@@ -487,8 +496,10 @@ export class RecentsWidget extends Component {
       } = widgetError);
     }
 
+    const isWebRTCSupported = media.getIn(['webRTC', 'isSupported']);
+
     if (spacesList && hasFetchedSpaces) {
-      if (incomingCall) {
+      if (incomingCall && isWebRTCSupported) {
         const space = this.getSpaceFromCall(incomingCall);
         return (
           <div className={classNames('ciscospark-recents-widget', styles.recentsWidget)}>
@@ -504,6 +515,8 @@ export class RecentsWidget extends Component {
           </div>
         );
       }
+
+      const handleCallClick = isWebRTCSupported ? this.handleSpaceCallClick : undefined;
       return (
         <div className={classNames('ciscospark-recents-widget', styles.recentsWidget)}>
           {
@@ -521,7 +534,7 @@ export class RecentsWidget extends Component {
               currentUser={currentUser}
               formatMessage={formatMessage}
               hasGroupCalling={hasGroupCalling}
-              onCallClick={this.handleSpaceCallClick}
+              onCallClick={handleCallClick}
               onClick={this.handleSpaceClick}
               spaces={spacesList}
             />
@@ -574,6 +587,7 @@ export default connect(
   (dispatch) => bindActionCreators({
     acknowledgeSpace,
     addError,
+    checkWebRTCSupport,
     connectToMercury,
     declineIncomingCall,
     dismissIncomingCall,

--- a/packages/node_modules/@ciscospark/widget-recents/src/reducer.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/reducer.js
@@ -1,46 +1,33 @@
 import {fromJS} from 'immutable';
-import mercury from '@ciscospark/redux-module-mercury';
-import users from '@ciscospark/redux-module-users';
-import spaces from '@ciscospark/redux-module-spaces';
+
+import avatar from '@ciscospark/redux-module-avatar';
 import errors from '@ciscospark/redux-module-errors';
 import features from '@ciscospark/redux-module-features';
-import avatar from '@ciscospark/redux-module-avatar';
+import media from '@ciscospark/redux-module-media';
+import mercury from '@ciscospark/redux-module-mercury';
+import spaces from '@ciscospark/redux-module-spaces';
 import teams from '@ciscospark/redux-module-teams';
+import users from '@ciscospark/redux-module-users';
+
 
 import {
   UPDATE_STATUS,
-  STORE_INCOMING_CALL,
-  DELETE_INCOMING_CALL,
-  UPDATE_WEBRTC_SUPPORT,
   UPDATE_VISIBILITY_COUNT
 } from './actions';
 
 export const initialState = fromJS({
-  incomingCall: null,
   visibilityCount: 15,
   status: {
     hasFetchedFeatureFlags: false,
     isFetchingFeatureFlags: false,
-    isListeningForNewActivity: false,
-    isListeningForCalls: false,
-    hasCheckedWebRTCSupport: false,
-    hasWebRTCSupport: false
+    isListeningForNewActivity: false
   }
 });
 
 export function reducer(state = initialState, action) {
   switch (action.type) {
-    case STORE_INCOMING_CALL:
-      return state.set('incomingCall', action.payload.call);
-
-    case DELETE_INCOMING_CALL:
-      return state.set('incomingCall', null);
-
     case UPDATE_STATUS:
       return state.mergeIn(['status'], action.payload.status);
-
-    case UPDATE_WEBRTC_SUPPORT:
-      return state.setIn(['status', 'hasWebRTCSupport'], action.payload.support);
 
     case UPDATE_VISIBILITY_COUNT:
       return state.set('visibilityCount', action.payload.count);
@@ -52,12 +39,13 @@ export function reducer(state = initialState, action) {
 
 const reducers = {
   avatar,
-  users,
-  mercury,
-  spaces,
   errors,
   features,
+  media,
+  mercury,
+  spaces,
   teams,
+  users,
   widgetRecents: reducer
 };
 

--- a/packages/node_modules/@ciscospark/widget-recents/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/selector.js
@@ -4,14 +4,16 @@ import {OrderedMap} from 'immutable';
 import {formatDate} from '@ciscospark/react-component-utils';
 import {FEATURE_GROUP_CALLING} from '@ciscospark/redux-module-features';
 
-const getWidget = (state) => state.widgetRecents;
-const getSpark = (state) => state.spark;
-const getUsers = (state) => state.users;
-const getCurrentUser = (state, ownProps) => ownProps.currentUser;
 const getAvatars = (state) => state.avatar;
-const getSpaces = (state) => state.spaces;
-const getTeams = (state) => state.teams;
+const getCurrentUser = (state, ownProps) => ownProps.currentUser;
 const getFeatures = (state) => state.features;
+const getCalls = (state) => state.media.get('calls');
+const getSpaces = (state) => state.spaces;
+const getSpark = (state) => state.spark;
+const getTeams = (state) => state.teams;
+const getUsers = (state) => state.users;
+const getWidget = (state) => state.widgetRecents;
+
 
 function sortByNewest(space) {
   return -moment(space.get('lastReadableActivityDate')).format('x');
@@ -123,19 +125,25 @@ const getRecentSpacesWithAvatarUrl = createSelector(
   }
 );
 
+const getIncomingCall = createSelector(
+  [getCalls],
+  (calls) => calls.find((call) => call.isIncoming && !call.isDismissed)
+);
 
 const getRecentsWidgetProps = createSelector(
   [
     getWidget,
     getRecentSpacesWithAvatarUrl,
     getSpark,
-    getFeatures
+    getFeatures,
+    getIncomingCall
   ],
   (
     widget,
     spacesList,
     spark,
-    features
+    features,
+    incomingCall
   ) => {
     let lastActivityDate;
     if (spacesList && spacesList.count()) {
@@ -149,7 +157,8 @@ const getRecentsWidgetProps = createSelector(
       widgetRecents: widget,
       spacesList,
       hasGroupCalling,
-      lastActivityDate
+      lastActivityDate,
+      incomingCall
     };
   }
 );


### PR DESCRIPTION
This is the first part of the recents call tracking feature, but broken into a more manageable PR. It does two things:
- Converts call objects in media module to records
- Uses media module for incoming call tracking in Recents widget