### PR TITLE
chore(package): update babel-plugin-lodash to version 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "babel-core": "^6.22.1",
     "babel-eslint": "^8.0.2",
     "babel-loader": "^7.1.1",
-    "babel-plugin-lodash": "^3.2.11",
+    "babel-plugin-lodash": "^3.3.2",
     "babel-plugin-react-transform": "^3.0.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",


### PR DESCRIPTION
closes #563 