### PR TITLE
fix(redux-module-media): listen for declined incoming events

### DIFF
--- a/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/actions.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/actions.test.js.snap
@@ -175,38 +175,9 @@ exports[`redux-module-media actions  #declineIncomingCall can successfully decli
 Array [
   Object {
     "payload": Object {
-      "call": Object {
-        "acknowledge": [MockFunction],
-        "answer": [MockFunction],
-        "direction": "",
-        "hangup": [MockFunction],
-        "joined": "",
-        "joinedOnThisDevice": "",
-        "localMediaStream": "",
-        "locus": Object {
-          "url": "https://locusUrl",
-        },
-        "off": [MockFunction],
-        "on": [MockFunction],
-        "once": [MockFunction],
-        "receivingAudio": "",
-        "reject": [MockFunction] {
-          "calls": Array [
-            Array [],
-          ],
-        },
-        "remoteAudioMuted": "",
-        "remoteAudioStream": "",
-        "remoteMediaStream": "",
-        "remoteVideoMuted": "",
-        "remoteVideoStream": "",
-        "sendingAudio": "",
-        "sendingVideo": "",
-        "status": "",
-      },
-      "locusUrl": undefined,
+      "callId": "https://locusUrl",
     },
-    "type": "media/REMOVE_CALL",
+    "type": "media/DISMISS_INCOMING_CALL",
   },
 ]
 `;
@@ -309,6 +280,10 @@ Array [
         "off": [MockFunction],
         "on": [MockFunction] {
           "calls": Array [
+            Array [
+              "membership:declined",
+              [Function],
+            ],
             Array [
               "membership:change",
               [Function],
@@ -524,6 +499,7 @@ Array [
 
 exports[`redux-module-media actions  has exported actions 1`] = `
 Object {
+  "ANSWERED_INCOMING_CALL": "media/ANSWERED_INCOMING_CALL",
   "CHECKING_WEB_RTC_SUPPORT": "media/CHECKING_WEB_RTC_SUPPORT",
   "CONNECT_CALL": "media/CONNECT_CALL",
   "DISMISS_INCOMING_CALL": "media/DISMISS_INCOMING_CALL",

--- a/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/reducer.test.js.snap
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/__snapshots__/reducer.test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`redux-module-media reducer should handle ANSWERED_INCOMING_CALL 1`] = `
+Immutable.Map {
+  "calls": Immutable.Map {
+    "http://abc-123.gov": Immutable.Record {
+      "id": "http://abc-123.gov",
+      "instance": null,
+      "isAnswered": true,
+      "isDismissed": false,
+      "isIncoming": true,
+      "spaceId": null,
+      "callState": Object {},
+      "callStartTime": null,
+    },
+  },
+  "webRTC": Immutable.Map {
+    "hasCheckedSupport": false,
+    "isSupported": null,
+  },
+  "status": Immutable.Map {
+    "isListening": false,
+  },
+}
+`;
+
 exports[`redux-module-media reducer should handle CHECKING_WEB_RTC_SUPPORT 1`] = `
 Immutable.Map {
   "calls": Immutable.Map {},
@@ -28,6 +52,7 @@ Immutable.Map {
         },
         "mock": true,
       },
+      "isAnswered": false,
       "isDismissed": false,
       "isIncoming": false,
       "spaceId": null,
@@ -54,6 +79,7 @@ Immutable.Map {
     "http://abc-123.gov": Immutable.Record {
       "id": "http://abc-123.gov",
       "instance": null,
+      "isAnswered": false,
       "isDismissed": true,
       "isIncoming": true,
       "spaceId": null,
@@ -92,6 +118,7 @@ Immutable.Map {
       "instance": Object {
         "mock": true,
       },
+      "isAnswered": false,
       "isDismissed": false,
       "isIncoming": undefined,
       "spaceId": null,
@@ -117,6 +144,7 @@ Immutable.Map {
     "http://abc-123.gov": Immutable.Record {
       "id": "http://abc-123.gov",
       "instance": null,
+      "isAnswered": false,
       "isDismissed": false,
       "isIncoming": false,
       "spaceId": null,

--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.js
@@ -3,6 +3,7 @@ import {constructCallState} from './helpers';
 export const UPDATE_STATUS = 'media/UPDATE_STATUS';
 
 export const DISMISS_INCOMING_CALL = 'media/DISMISS_INCOMING_CALL';
+export const ANSWERED_INCOMING_CALL = 'media/ANSWERED_INCOMING_CALL';
 export const STORE_CALL = 'media/STORE_CALL';
 export const CONNECT_CALL = 'media/CONNECT_CALL';
 export const REMOVE_CALL = 'media/REMOVE_CALL';
@@ -100,6 +101,15 @@ export function dismissIncomingCall(callId) {
   };
 }
 
+function answeredIncomingCall(callId) {
+  return {
+    type: ANSWERED_INCOMING_CALL,
+    payload: {
+      callId
+    }
+  };
+}
+
 export function hangupCall({call, locusUrl}) {
   return (dispatch) => {
     // Don't update call states after hangup
@@ -176,6 +186,36 @@ export function placeCall({
 }
 
 /**
+ * Declines an incoming call
+ *
+ * @export
+ * @param {object} incomingCall
+ * @returns {Promise}
+ */
+export function declineIncomingCall(incomingCall) {
+  return (dispatch) => {
+    incomingCall.reject();
+    return dispatch(dismissIncomingCall(incomingCall.locus.url));
+  };
+}
+
+/**
+ * Answers a call object
+ * @param {object} incomingCall
+ * @param {string} locusUrl
+ * @returns {Promise}
+ */
+export function acceptIncomingCall(incomingCall, locusUrl) {
+  return (dispatch) =>
+    incomingCall.answer({offerOptions: {offerToReceiveVideo: true, offerToReceiveAudio: true}})
+      .then(() => {
+        bindEvents(dispatch, incomingCall, locusUrl);
+        return dispatch(connectCall(incomingCall));
+      });
+}
+
+
+/**
  * Listen for incoming calls and sets up call handling
  *
  * @export
@@ -205,46 +245,30 @@ export function listenForIncomingCalls(sparkInstance, locusUrl) {
           // If the remote party hangs up before we accept/decline
           incomingCall.once('inactive', removeIncoming);
 
-          // Once we are connected, our connected call state will handle disconnects
-          incomingCall.on('membership:change', () => {
-            if (incomingCall.me.state === 'connected') {
-              incomingCall.off('inactive', removeIncoming);
+          // If we rejected the call elsewhere, mark it declined
+          incomingCall.on('membership:declined', () => {
+            if (incomingCall.me.state === 'declined') {
+              dispatch(dismissIncomingCall(incomingCall.locus.url));
             }
           });
+
+          incomingCall.on('membership:change', () => {
+            // Once we are connected, our connected call state will handle disconnects
+            if (incomingCall.me.state === 'connected') {
+              dispatch(answeredIncomingCall(incomingCall.locus.url));
+              // incomingCall.joinedOnThisDevice takes a few ticks so we have to
+              // calculate it ourselves for now
+              if (incomingCall.locus.self.deviceUrl !== sparkInstance.internal.device.url) {
+                // We are not connected on this device, dismiss
+                dispatch(dismissIncomingCall(incomingCall.locus.url));
+              }
+            }
+          });
+
           return dispatch(storeCall(incomingCall, incomingCall.locus.url, true));
         });
     });
   };
-}
-
-/**
- * Declines an incoming call
- *
- * @export
- * @param {object} incomingCall
- * @returns {Promise}
- */
-export function declineIncomingCall(incomingCall) {
-  return (dispatch) => {
-    incomingCall.reject();
-    dispatch(removeCall(incomingCall));
-    return Promise.resolve();
-  };
-}
-
-/**
- * Answers a call object
- * @param {object} incomingCall
- * @param {string} locusUrl
- * @returns {Promise}
- */
-export function acceptIncomingCall(incomingCall, locusUrl) {
-  return (dispatch) =>
-    incomingCall.answer({offerOptions: {offerToReceiveVideo: true, offerToReceiveAudio: true}})
-      .then(() => {
-        bindEvents(dispatch, incomingCall, locusUrl);
-        return dispatch(connectCall(incomingCall));
-      });
 }
 
 /**

--- a/packages/node_modules/@ciscospark/redux-module-media/src/actions.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/actions.test.js
@@ -116,7 +116,8 @@ describe('redux-module-media actions ', () => {
             .then(() => {
               expect(call.acknowledge).toHaveBeenCalled();
               expect(call.once.mock.calls[0][0]).toBe('inactive');
-              expect(call.on.mock.calls[0][0]).toBe('membership:change');
+              expect(call.on.mock.calls[0][0]).toBe('membership:declined');
+              expect(call.on.mock.calls[1][0]).toBe('membership:change');
               expect(store.getActions()).toMatchSnapshot();
             });
         }));
@@ -124,12 +125,11 @@ describe('redux-module-media actions ', () => {
 
 
   describe('#declineIncomingCall', () => {
-    it('can successfully decline an incoming call', () =>
-      store.dispatch(actions.declineIncomingCall(call))
-        .then(() => {
-          expect(call.reject).toHaveBeenCalled();
-          expect(store.getActions()).toMatchSnapshot();
-        }));
+    it('can successfully decline an incoming call', () => {
+      store.dispatch(actions.declineIncomingCall(call));
+      expect(call.reject).toHaveBeenCalled();
+      expect(store.getActions()).toMatchSnapshot();
+    });
   });
 
 

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.js
@@ -1,6 +1,7 @@
 import {fromJS, Record} from 'immutable';
 
 import {
+  ANSWERED_INCOMING_CALL,
   DISMISS_INCOMING_CALL,
   UPDATE_STATUS,
   UPDATE_CALL_STATE,
@@ -14,6 +15,7 @@ import {
 export const CallRecord = new Record({
   id: null,
   instance: null,
+  isAnswered: false,
   isDismissed: false,
   isIncoming: false,
   spaceId: null,
@@ -84,6 +86,10 @@ export default function reducer(state = initialState, action) {
         return state.deleteIn(['calls', locusUrl]);
       }
       return state;
+    }
+
+    case ANSWERED_INCOMING_CALL: {
+      return state.setIn(['calls', action.payload.callId, 'isAnswered'], true);
     }
 
     case DISMISS_INCOMING_CALL: {

--- a/packages/node_modules/@ciscospark/redux-module-media/src/reducer.test.js
+++ b/packages/node_modules/@ciscospark/redux-module-media/src/reducer.test.js
@@ -1,5 +1,6 @@
 import reducer, {initialState, CallRecord} from './reducer';
 import {
+  ANSWERED_INCOMING_CALL,
   DISMISS_INCOMING_CALL,
   CHECKING_WEB_RTC_SUPPORT,
   CONNECT_CALL,
@@ -119,6 +120,19 @@ describe('redux-module-media reducer', () => {
 
     expect(reducer(updatedState, {
       type: DISMISS_INCOMING_CALL,
+      payload: {
+        callId: id
+      }
+    })).toMatchSnapshot();
+  });
+
+  it('should handle ANSWERED_INCOMING_CALL', () => {
+    const id = 'http://abc-123.gov';
+    const callRecord = new CallRecord({id, isIncoming: true});
+    const updatedState = initialState.setIn(['calls', id], callRecord);
+
+    expect(reducer(updatedState, {
+      type: ANSWERED_INCOMING_CALL,
       payload: {
         callId: id
       }

--- a/packages/node_modules/@ciscospark/widget-meet/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-meet/src/selector.js
@@ -73,9 +73,9 @@ const getMeetWidgetProps = createSelector(
     const hasCheckedWebRTCSupport = media.getIn(['webRTC', 'hasCheckedSupport']);
     const isWebRTCSupported = media.getIn(['webRTC', 'isSupported']);
 
-    let callFrom, callInstance, callIsActive, callIsIncoming, callIsRinging, callState;
+    let callFrom, callInstance, callIsActive, callIsIncoming, callIsRinging, callState, isDismissed;
     if (call) {
-      ({callState, instance: callInstance} = call);
+      ({callState, instance: callInstance, isDismissed} = call);
 
       // Is the call active?
       const {
@@ -89,7 +89,7 @@ const getMeetWidgetProps = createSelector(
 
       callIsRinging = ringing;
       callIsActive = connected && joinedOnThisDevice || direction === 'out';
-      callIsIncoming = direction === 'in' && !joinedOnThisDevice;
+      callIsIncoming = direction === 'in' && !joinedOnThisDevice && !isDismissed;
       if (isInitiated && typeof isCall === 'boolean') {
         callFrom = buildCallFrom(isCall, callInstance, conversation);
       }

--- a/packages/node_modules/@ciscospark/widget-recents/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-recents/src/selector.js
@@ -127,7 +127,7 @@ const getRecentSpacesWithAvatarUrl = createSelector(
 
 const getIncomingCall = createSelector(
   [getCalls],
-  (calls) => calls.find((call) => call.isIncoming && !call.isDismissed)
+  (calls) => calls.find((call) => call.isIncoming && !call.isDismissed && !call.isAnswered)
 );
 
 const getRecentsWidgetProps = createSelector(

--- a/packages/node_modules/@ciscospark/widget-space/src/selector.js
+++ b/packages/node_modules/@ciscospark/widget-space/src/selector.js
@@ -67,7 +67,13 @@ export const getActivityTypes = createSelector(
 
 const getCall = createSelector(
   [getConversation, getMedia],
-  (conversation, media) => media.getIn(['calls', conversation.get('locusUrl')])
+  (conversation, media) => {
+    const call = media.getIn(['calls', conversation.get('locusUrl')]);
+    if (call && call.isDismissed) {
+      return null;
+    }
+    return call;
+  }
 );
 
 


### PR DESCRIPTION
Our recents widget will not hide the incoming call screen if the call is handled outside of the recents widget. This will handle the "decline from elsewhere" state. The "answer from elsewhere" state will need an sdk feature.