### PR TITLE
chore: add standard-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1198 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+
+<a name="0.1.269"></a>
+## [0.1.269](https://github.com/ciscospark/react-ciscospark/compare/v0.1.268...v0.1.269) (2018-03-20)
+
+
+
+<a name="0.1.268"></a>
+## [0.1.268](https://github.com/ciscospark/react-ciscospark/compare/v0.1.267...v0.1.268) (2018-03-20)
+
+
+
+<a name="0.1.267"></a>
+## [0.1.267](https://github.com/ciscospark/react-ciscospark/compare/v0.1.266...v0.1.267) (2018-03-19)
+
+
+### Bug Fixes
+
+* **redux-module-conversation:** set conversation error message ([9afaa4c](https://github.com/ciscospark/react-ciscospark/commit/9afaa4c))
+* **widget-meet:** remove duplicate incoming call handler ([2d04b7e](https://github.com/ciscospark/react-ciscospark/commit/2d04b7e))
+* **widget-space:** handle uuids for toPersonId ([3c125ae](https://github.com/ciscospark/react-ciscospark/commit/3c125ae))
+
+
+### Features
+
+* **demo-widget:** add to user id support ([c7bc756](https://github.com/ciscospark/react-ciscospark/commit/c7bc756))
+* **react-component-utils:** add hydraTypes object ([e1eeb24](https://github.com/ciscospark/react-ciscospark/commit/e1eeb24))
+* **redux-module-conversation:** add hydra id support to create and get ([741b522](https://github.com/ciscospark/react-ciscospark/commit/741b522))
+
+
+
+<a name="0.1.266"></a>
+## [0.1.266](https://github.com/ciscospark/react-ciscospark/compare/v0.1.265...v0.1.266) (2018-03-16)
+
+
+
+<a name="0.1.265"></a>
+## [0.1.265](https://github.com/ciscospark/react-ciscospark/compare/v0.1.264...v0.1.265) (2018-03-15)
+
+
+
+<a name="0.1.264"></a>
+## [0.1.264](https://github.com/ciscospark/react-ciscospark/compare/v0.1.263...v0.1.264) (2018-03-15)
+
+
+### Bug Fixes
+
+* **redux-module-media:** listen for declined incoming events ([a2fbba2](https://github.com/ciscospark/react-ciscospark/commit/a2fbba2))
+
+
+### Features
+
+* **redux-module-media:** add #checkCurrentCalls method ([6a76fda](https://github.com/ciscospark/react-ciscospark/commit/6a76fda))
+* **redux-module-media:** add support for call:created event ([83a14cc](https://github.com/ciscospark/react-ciscospark/commit/83a14cc))
+* **redux-module-media:** get callStartTime on STORE_CALL ([2b9fac3](https://github.com/ciscospark/react-ciscospark/commit/2b9fac3))
+* **redux-module-media:** listen for all calls in enhancer ([388216b](https://github.com/ciscospark/react-ciscospark/commit/388216b))
+* **redux-module-spaces:** store locusUrl in space record ([b216068](https://github.com/ciscospark/react-ciscospark/commit/b216068))
+* **widget-recents:** add associated call to space ([2e48842](https://github.com/ciscospark/react-ciscospark/commit/2e48842))
+* **widget-recents:** check for current calls after spaces load ([86dc578](https://github.com/ciscospark/react-ciscospark/commit/86dc578))
+* **widget-recents:** display join call button on space ([6bda887](https://github.com/ciscospark/react-ciscospark/commit/6bda887))
+* **widget-recents:** use call.startTime prop ([88bb29d](https://github.com/ciscospark/react-ciscospark/commit/88bb29d))
+* **widget-recents:** use media enhancer ([b188970](https://github.com/ciscospark/react-ciscospark/commit/b188970))
+* **widget-recents:** use media's listenForCalls method ([5aa3e0b](https://github.com/ciscospark/react-ciscospark/commit/5aa3e0b))
+* **widget-recents:** use space locusUrl to match to existing call ([a3db765](https://github.com/ciscospark/react-ciscospark/commit/a3db765))
+
+
+
+<a name="0.1.263"></a>
+## [0.1.263](https://github.com/ciscospark/react-ciscospark/compare/v0.1.262...v0.1.263) (2018-03-15)
+
+
+### Bug Fixes
+
+* **journeys:** remove check for in flight flag ([a380fe9](https://github.com/ciscospark/react-ciscospark/commit/a380fe9))
+* **react-container-activity-list:** Add filter to remove extra new lines ([127f0be](https://github.com/ciscospark/react-ciscospark/commit/127f0be))
+* **react-container-message-composer:** Proptypes error from mention lib ([6213369](https://github.com/ciscospark/react-ciscospark/commit/6213369))
+* **redux-module-activity:** Add filter to remove extra new lines ([280a04c](https://github.com/ciscospark/react-ciscospark/commit/280a04c))
+* **redux-module-activity:** raw url converts properly ([1b84205](https://github.com/ciscospark/react-ciscospark/commit/1b84205))
+* **widget-meet:** Use userId when fetching avatar for direct space ([189319a](https://github.com/ciscospark/react-ciscospark/commit/189319a))
+* **widget-message:** Fix unhandled exception when adding invalid files ([6da933f](https://github.com/ciscospark/react-ciscospark/commit/6da933f))
+* **widget-message:** Incorrect events payload ([b5fafc4](https://github.com/ciscospark/react-ciscospark/commit/b5fafc4))
+* **widget-module-flags:** Prevent multiple flagging calls ([c752e1b](https://github.com/ciscospark/react-ciscospark/commit/c752e1b))
+
+
+### Features
+
+* **react-component-activity-item-base:** add action pending class ([181730e](https://github.com/ciscospark/react-ciscospark/commit/181730e))
+* **react-component-activity-list:** add support for isFlagPending ([1ebf5fa](https://github.com/ciscospark/react-ciscospark/commit/1ebf5fa))
+* **react-container-activity-list:** add support for isFlagPending ([b4dec3b](https://github.com/ciscospark/react-ciscospark/commit/b4dec3b))
+
+
+
+<a name="0.1.262"></a>
+## [0.1.262](https://github.com/ciscospark/react-ciscospark/compare/v0.1.261...v0.1.262) (2018-03-01)
+
+
+### Bug Fixes
+
+* **react-container-activity-list:** timestamp does not update when minute changes ([2849357](https://github.com/ciscospark/react-ciscospark/commit/2849357))
+
+
+
+<a name="0.1.261"></a>
+## [0.1.261](https://github.com/ciscospark/react-ciscospark/compare/v0.1.260...v0.1.261) (2018-02-28)
+
+
+### Bug Fixes
+
+* **redux-module-spaces:** add support for empty lastReadableActivityDate ([82c3284](https://github.com/ciscospark/react-ciscospark/commit/82c3284))
+* **widget-recents:** add incoming call to selector ([95a4009](https://github.com/ciscospark/react-ciscospark/commit/95a4009))
+* **widget-recents:** add support for empty latestActivity ([b98e1db](https://github.com/ciscospark/react-ciscospark/commit/b98e1db))
+
+
+### Features
+
+* **redux-module-media:** add isIncoming prop to call record ([2dfaa96](https://github.com/ciscospark/react-ciscospark/commit/2dfaa96))
+
+
+
+<a name="0.1.260"></a>
+## [0.1.260](https://github.com/ciscospark/react-ciscospark/compare/v0.1.259...v0.1.260) (2018-02-28)
+
+
+### Features
+
+* **journeys:** add single integration suite to run all tests ([69bafe2](https://github.com/ciscospark/react-ciscospark/commit/69bafe2))
+
+
+
+<a name="0.1.259"></a>
+## [0.1.259](https://github.com/ciscospark/react-ciscospark/compare/v0.1.258...v0.1.259) (2018-02-24)
+
+
+
+<a name="0.1.258"></a>
+## [0.1.258](https://github.com/ciscospark/react-ciscospark/compare/v0.1.257...v0.1.258) (2018-02-22)
+
+
+### Bug Fixes
+
+* **react-container-message-composer:** check for empty message before submit ([b4d21df](https://github.com/ciscospark/react-ciscospark/commit/b4d21df))
+* **react-container-notifications:** eslint errors ([41aa9a2](https://github.com/ciscospark/react-ciscospark/commit/41aa9a2))
+* **redux-module-activity:** check for empty message before submit ([bddf2af](https://github.com/ciscospark/react-ciscospark/commit/bddf2af))
+* **widget-recents:** Small fixes for validation ([70ea113](https://github.com/ciscospark/react-ciscospark/commit/70ea113))
+* **widget-space:** Allow passing to prop to meet ([f7b7b96](https://github.com/ciscospark/react-ciscospark/commit/f7b7b96))
+* remove debug code and fix journey test error messages ([e2f3844](https://github.com/ciscospark/react-ciscospark/commit/e2f3844))
+
+
+
+<a name="0.1.257"></a>
+## [0.1.257](https://github.com/ciscospark/react-ciscospark/compare/v0.1.256...v0.1.257) (2018-02-21)
+
+
+### Bug Fixes
+
+* **react-container-message-composer:** check for empty message before submit ([9912c6e](https://github.com/ciscospark/react-ciscospark/commit/9912c6e))
+* **react-container-notifications:** eslint errors ([b35d95f](https://github.com/ciscospark/react-ciscospark/commit/b35d95f))
+* **react-container-notifications:** eslint errors ([cdf5346](https://github.com/ciscospark/react-ciscospark/commit/cdf5346))
+* **redux-module-activity:** check for empty message before submit ([2c1a5fd](https://github.com/ciscospark/react-ciscospark/commit/2c1a5fd))
+
+
+
+<a name="0.1.256"></a>
+## [0.1.256](https://github.com/ciscospark/react-ciscospark/compare/v0.1.255...v0.1.256) (2018-02-19)
+
+
+
+<a name="0.1.255"></a>
+## [0.1.255](https://github.com/ciscospark/react-ciscospark/compare/v0.1.254...v0.1.255) (2018-02-19)
+
+
+### Bug Fixes
+
+* **react-container-notifications:** Add checks to unsent selector ([68b0531](https://github.com/ciscospark/react-ciscospark/commit/68b0531))
+* **redux-module-media:** listen for declined incoming events ([f07154f](https://github.com/ciscospark/react-ciscospark/commit/f07154f))
+* **redux-module-users:** Check for photo before trying to save ([be62793](https://github.com/ciscospark/react-ciscospark/commit/be62793))
+* **widget-recents:** Misaligned object keys ([f65f0f7](https://github.com/ciscospark/react-ciscospark/commit/f65f0f7))
+* **widget-recents:** Missed activities module updates ([7403d63](https://github.com/ciscospark/react-ciscospark/commit/7403d63))
+
+
+### Features
+
+* **widget-meet:** use isDismissed call flag ([5cd6b7c](https://github.com/ciscospark/react-ciscospark/commit/5cd6b7c))
+* **widget-recents:** use isAnswered for incoming call status ([03ddb8e](https://github.com/ciscospark/react-ciscospark/commit/03ddb8e))
+* **widget-space:** use isDismissed call flag ([e458c25](https://github.com/ciscospark/react-ciscospark/commit/e458c25))
+* Update widget build to use production env ([e78275e](https://github.com/ciscospark/react-ciscospark/commit/e78275e))
+
+
+
+<a name="0.1.254"></a>
+## [0.1.254](https://github.com/ciscospark/react-ciscospark/compare/v0.1.253...v0.1.254) (2018-02-19)
+
+
+### Bug Fixes
+
+* **react-container-notification:** Remove conversation dependency ([4f87917](https://github.com/ciscospark/react-ciscospark/commit/4f87917))
+* **redux-module-media:** Missing exports, undefined errors, eslint ([737db2c](https://github.com/ciscospark/react-ciscospark/commit/737db2c))
+* **redux-module-spaces:** Add initial space placeholder ([8a53ea6](https://github.com/ciscospark/react-ciscospark/commit/8a53ea6))
+
+
+### Features
+
+* **react-component-utils:** Add more hoc and string helpers ([558f0c4](https://github.com/ciscospark/react-ciscospark/commit/558f0c4))
+* **react-container-activity-list:** Update to use users redux module ([cb2f236](https://github.com/ciscospark/react-ciscospark/commit/cb2f236))
+* **react-container-message-composer:** Migrate to users module ([6e76d03](https://github.com/ciscospark/react-ciscospark/commit/6e76d03))
+* **react-container-read-receipts:** Migrate to users module ([bdae229](https://github.com/ciscospark/react-ciscospark/commit/bdae229))
+* **react-redux-spark:** Migrate to immutable Records ([e34f86d](https://github.com/ciscospark/react-ciscospark/commit/e34f86d))
+* **redux-module-activities:** Update to use Records for initialState ([53f8d7e](https://github.com/ciscospark/react-ciscospark/commit/53f8d7e))
+* **redux-module-avatar:** Export addAvatar action ([5aefdb6](https://github.com/ciscospark/react-ciscospark/commit/5aefdb6))
+* **redux-module-mercury:** Add connect to mercury enhancer ([dbbe092](https://github.com/ciscospark/react-ciscospark/commit/dbbe092))
+* **redux-module-spaces:** Use immutable Records ([4f8dbca](https://github.com/ciscospark/react-ciscospark/commit/4f8dbca))
+* **redux-modules-users:** Add avatar storage when storing users ([95160da](https://github.com/ciscospark/react-ciscospark/commit/95160da))
+* **widget-meet:** Add meet index.html page ([35702dd](https://github.com/ciscospark/react-ciscospark/commit/35702dd))
+* **widget-message:** Migrate to users module ([8a71e37](https://github.com/ciscospark/react-ciscospark/commit/8a71e37))
+
+
+
+<a name="0.1.253"></a>
+## [0.1.253](https://github.com/ciscospark/react-ciscospark/compare/v0.1.252...v0.1.253) (2018-02-16)
+
+
+
+<a name="0.1.252"></a>
+## [0.1.252](https://github.com/ciscospark/react-ciscospark/compare/v0.1.251...v0.1.252) (2018-02-16)
+
+
+### Bug Fixes
+
+* **journeys:** moveToObject uses offsets differently than actions ([83d1265](https://github.com/ciscospark/react-ciscospark/commit/83d1265))
+* **journeys:** tests do not wait for menu button to be visible ([5ca3c56](https://github.com/ciscospark/react-ciscospark/commit/5ca3c56))
+* **spark-widget-base:** Apply middleware correctly to re-enable logger. ([7a6cce1](https://github.com/ciscospark/react-ciscospark/commit/7a6cce1))
+
+
+### Features
+
+* **redux-module-activities:** New activities module ([6961e73](https://github.com/ciscospark/react-ciscospark/commit/6961e73))
+
+
+
+<a name="0.1.251"></a>
+## [0.1.251](https://github.com/ciscospark/react-ciscospark/compare/v0.1.250...v0.1.251) (2018-02-07)
+
+
+
+<a name="0.1.250"></a>
+## [0.1.250](https://github.com/ciscospark/react-ciscospark/compare/v0.1.249...v0.1.250) (2018-02-07)
+
+
+### Features
+
+* **react-redux-spark:** add ability to use jwt token to authenticate ([27f541d](https://github.com/ciscospark/react-ciscospark/commit/27f541d))
+* **widget-demo:** ability to open widget with jwtToken ([e576606](https://github.com/ciscospark/react-ciscospark/commit/e576606))
+
+
+
+<a name="0.1.249"></a>
+## [0.1.249](https://github.com/ciscospark/react-ciscospark/compare/v0.1.248...v0.1.249) (2018-02-06)
+
+
+### Bug Fixes
+
+* **spark-widget-base:** Add version and fix .on events ([c853ac0](https://github.com/ciscospark/react-ciscospark/commit/c853ac0))
+* **spark-widget-base:** Fix event details structure ([9308fdb](https://github.com/ciscospark/react-ciscospark/commit/9308fdb))
+
+
+
+<a name="0.1.248"></a>
+## [0.1.248](https://github.com/ciscospark/react-ciscospark/compare/v0.1.247...v0.1.248) (2018-02-05)
+
+
+### Bug Fixes
+
+* **tooling:** Increase maxDuration for journey tests ([0dbbf30](https://github.com/ciscospark/react-ciscospark/commit/0dbbf30))
+
+
+
+<a name="0.1.247"></a>
+## [0.1.247](https://github.com/ciscospark/react-ciscospark/compare/v0.1.246...v0.1.247) (2018-01-25)
+
+
+### Features
+
+* **journeys:** use location and size of element to move mouse in FF ([ba81df9](https://github.com/ciscospark/react-ciscospark/commit/ba81df9))
+* **journeys:** use new moveMouse defaults ([3ca3583](https://github.com/ciscospark/react-ciscospark/commit/3ca3583))
+* **react-component-typing-avatar:** changed style to match web client ([6188f6a](https://github.com/ciscospark/react-ciscospark/commit/6188f6a))
+
+
+
+<a name="0.1.246"></a>
+## [0.1.246](https://github.com/ciscospark/react-ciscospark/compare/v0.1.245...v0.1.246) (2018-01-19)
+
+
+
+<a name="0.1.245"></a>
+## [0.1.245](https://github.com/ciscospark/react-ciscospark/compare/v0.1.244...v0.1.245) (2018-01-19)
+
+
+
+<a name="0.1.244"></a>
+## [0.1.244](https://github.com/ciscospark/react-ciscospark/compare/v0.1.243...v0.1.244) (2018-01-19)
+
+
+
+<a name="0.1.243"></a>
+## [0.1.243](https://github.com/ciscospark/react-ciscospark/compare/v0.1.242...v0.1.243) (2018-01-18)
+
+
+
+<a name="0.1.242"></a>
+## [0.1.242](https://github.com/ciscospark/react-ciscospark/compare/v0.1.241...v0.1.242) (2018-01-17)
+
+
+
+<a name="0.1.241"></a>
+## [0.1.241](https://github.com/ciscospark/react-ciscospark/compare/v0.1.240...v0.1.241) (2018-01-16)
+
+
+
+<a name="0.1.240"></a>
+## [0.1.240](https://github.com/ciscospark/react-ciscospark/compare/v0.1.239...v0.1.240) (2018-01-16)
+
+
+
+<a name="0.1.239"></a>
+## [0.1.239](https://github.com/ciscospark/react-ciscospark/compare/v0.1.238...v0.1.239) (2018-01-16)
+
+
+
+<a name="0.1.238"></a>
+## [0.1.238](https://github.com/ciscospark/react-ciscospark/compare/v0.1.237...v0.1.238) (2018-01-16)
+
+
+
+<a name="0.1.237"></a>
+## [0.1.237](https://github.com/ciscospark/react-ciscospark/compare/v0.1.236...v0.1.237) (2018-01-16)
+
+
+
+<a name="0.1.236"></a>
+## [0.1.236](https://github.com/ciscospark/react-ciscospark/compare/v0.1.235...v0.1.236) (2018-01-16)
+
+
+### Bug Fixes
+
+* **all:** Add files and remove version from package.json ([4722e98](https://github.com/ciscospark/react-ciscospark/commit/4722e98))
+* **redux-module-activity:** add message parsing abilities to match other clients ([b73dac9](https://github.com/ciscospark/react-ciscospark/commit/b73dac9))
+* **widget-recents:** handle latestActivity that contains html ([51f8d9a](https://github.com/ciscospark/react-ciscospark/commit/51f8d9a))
+* **widget-roster:** display in flight participants properly ([534fdf2](https://github.com/ciscospark/react-ciscospark/commit/534fdf2))
+
+
+### Features
+
+* **react-component-activity-share-thumbnail:** add image alt text ([efb99c7](https://github.com/ciscospark/react-ciscospark/commit/efb99c7))
+* **react-component-people-list:** add email display on hover ([03532a2](https://github.com/ciscospark/react-ciscospark/commit/03532a2))
+* **widget-demo:** add ability to close running space when opening new one ([9bf42a5](https://github.com/ciscospark/react-ciscospark/commit/9bf42a5))
+
+
+
+<a name="0.1.235"></a>
+## [0.1.235](https://github.com/ciscospark/react-ciscospark/compare/v0.1.234...v0.1.235) (2018-01-10)
+
+
+### Features
+
+* **redux-module-media:** add incoming flags to call record ([9f3a3a6](https://github.com/ciscospark/react-ciscospark/commit/9f3a3a6))
+* **redux-module-media:** change call object to Record ([39c48ca](https://github.com/ciscospark/react-ciscospark/commit/39c48ca))
+* **widget-meet:** update to call object record ([d282d1d](https://github.com/ciscospark/react-ciscospark/commit/d282d1d))
+* **widget-recents:** use incoming call methods from media module ([19c46e9](https://github.com/ciscospark/react-ciscospark/commit/19c46e9))
+* **widget-recents:** use media module webRTC check ([59c74f2](https://github.com/ciscospark/react-ciscospark/commit/59c74f2))
+
+
+
+<a name="0.1.234"></a>
+## [0.1.234](https://github.com/ciscospark/react-ciscospark/compare/v0.1.233...v0.1.234) (2018-01-08)
+
+
+
+<a name="0.1.233"></a>
+## [0.1.233](https://github.com/ciscospark/react-ciscospark/compare/v0.1.232...v0.1.233) (2018-01-08)
+
+
+
+<a name="0.1.232"></a>
+## [0.1.232](https://github.com/ciscospark/react-ciscospark/compare/v0.1.231...v0.1.232) (2018-01-08)
+
+
+### Bug Fixes
+
+* **redux-module-spaces:** Use snapshot for checking exports ([753628c](https://github.com/ciscospark/react-ciscospark/commit/753628c))
+
+
+### Features
+
+* **widget-message:** change scroll lock behavior ([3d4ad5b](https://github.com/ciscospark/react-ciscospark/commit/3d4ad5b))
+
+
+
+<a name="0.1.231"></a>
+## [0.1.231](https://github.com/ciscospark/react-ciscospark/compare/v0.1.230...v0.1.231) (2018-01-08)
+
+
+
+<a name="0.1.230"></a>
+## [0.1.230](https://github.com/ciscospark/react-ciscospark/compare/v0.1.229...v0.1.230) (2018-01-08)
+
+
+### Bug Fixes
+
+* **redux-module-spaces:** Fix failed snapshot tests ([424af0f](https://github.com/ciscospark/react-ciscospark/commit/424af0f))
+* **spark-widget-base:** Fix missing props not being passed ([ba87360](https://github.com/ciscospark/react-ciscospark/commit/ba87360))
+* **widget-base:** Remove old base ([e8aea00](https://github.com/ciscospark/react-ciscospark/commit/e8aea00))
+
+
+### Features
+
+* **react-component-utils:** Add deconstruct Hydra ID ([f942663](https://github.com/ciscospark/react-ciscospark/commit/f942663))
+* **redux-module-spaces:** Add users module support ([51daa6a](https://github.com/ciscospark/react-ciscospark/commit/51daa6a))
+* **redux-module-users:** New users module ([b98050b](https://github.com/ciscospark/react-ciscospark/commit/b98050b))
+* **space-widget-base:** Add currrent user prop to intial setup ([11f0f7a](https://github.com/ciscospark/react-ciscospark/commit/11f0f7a))
+* **widget-demo:** add ability to open space from recents ([acb2439](https://github.com/ciscospark/react-ciscospark/commit/acb2439))
+* **widget-recents:** Convert to use new users module ([7b883ee](https://github.com/ciscospark/react-ciscospark/commit/7b883ee))
+
+
+
+<a name="0.1.229"></a>
+## [0.1.229](https://github.com/ciscospark/react-ciscospark/compare/v0.1.228...v0.1.229) (2018-01-05)
+
+
+### Features
+
+* **react-component-activity-menu-header:** initial component ([b142852](https://github.com/ciscospark/react-ciscospark/commit/b142852))
+* **react-component-file-share-display:** initial component ([4ee6c8c](https://github.com/ciscospark/react-ciscospark/commit/4ee6c8c))
+* **react-component-icon:** add files icon ([f64da28](https://github.com/ciscospark/react-ciscospark/commit/f64da28))
+* **widget-files:** initial implementation ([253d2f5](https://github.com/ciscospark/react-ciscospark/commit/253d2f5))
+* **widget-files:** use file downloader component ([faf605c](https://github.com/ciscospark/react-ciscospark/commit/faf605c))
+* **widget-files:** use FileShareDisplay component ([e60df81](https://github.com/ciscospark/react-ciscospark/commit/e60df81))
+* **widget-space:** add files button to menu ([6b4926e](https://github.com/ciscospark/react-ciscospark/commit/6b4926e))
+* **widget-space:** show error when no space destination is provided ([6a24c28](https://github.com/ciscospark/react-ciscospark/commit/6a24c28))
+
+
+
+<a name="0.1.228"></a>
+## [0.1.228](https://github.com/ciscospark/react-ciscospark/compare/v0.1.227...v0.1.228) (2018-01-05)
+
+
+### Bug Fixes
+
+* **tooling:** Add build URL to SRI ([5a61864](https://github.com/ciscospark/react-ciscospark/commit/5a61864))
+
+
+
+<a name="0.1.227"></a>
+## [0.1.227](https://github.com/ciscospark/react-ciscospark/compare/v0.1.226...v0.1.227) (2018-01-05)
+
+
+
+<a name="0.1.226"></a>
+## [0.1.226](https://github.com/ciscospark/react-ciscospark/compare/v0.1.225...v0.1.226) (2018-01-05)
+
+
+
+<a name="0.1.225"></a>
+## [0.1.225](https://github.com/ciscospark/react-ciscospark/compare/v0.1.224...v0.1.225) (2018-01-04)
+
+
+### Bug Fixes
+
+* **widget-message:** activities are no longer an immutable object ([d793e7b](https://github.com/ciscospark/react-ciscospark/commit/d793e7b))
+
+
+### Features
+
+* **widget-demo:** initial package ([9ac14ee](https://github.com/ciscospark/react-ciscospark/commit/9ac14ee))
+
+
+
+<a name="0.1.224"></a>
+## [0.1.224](https://github.com/ciscospark/react-ciscospark/compare/v0.1.223...v0.1.224) (2018-01-04)
+
+
+### Bug Fixes
+
+* **tooling:** Fix jenkins error ([912f99e](https://github.com/ciscospark/react-ciscospark/commit/912f99e))
+
+
+
+<a name="0.1.223"></a>
+## [0.1.223](https://github.com/ciscospark/react-ciscospark/compare/v0.1.222...v0.1.223) (2018-01-03)
+
+
+### Bug Fixes
+
+* **tooling:** Move redux-logger to main dep ([d0c3a24](https://github.com/ciscospark/react-ciscospark/commit/d0c3a24))
+
+
+
+<a name="0.1.222"></a>
+## [0.1.222](https://github.com/ciscospark/react-ciscospark/compare/v0.1.221...v0.1.222) (2018-01-03)
+
+
+### Bug Fixes
+
+* **spark-widget-base:** Fix eventing API ([8ef4f66](https://github.com/ciscospark/react-ciscospark/commit/8ef4f66))
+
+
+
+<a name="0.1.221"></a>
+## [0.1.221](https://github.com/ciscospark/react-ciscospark/compare/0426d8e...v0.1.221) (2018-01-02)
+
+
+### Bug Fixes
+
+* Add check for immutable object is defined ([6dde18b](https://github.com/ciscospark/react-ciscospark/commit/6dde18b))
+* Add file-saver dep ([04254d7](https://github.com/ciscospark/react-ciscospark/commit/04254d7))
+* add static version of webrtc-adapter ([8894969](https://github.com/ciscospark/react-ciscospark/commit/8894969))
+* All eslint errors and jest snapshots ([786028f](https://github.com/ciscospark/react-ciscospark/commit/786028f))
+* Check for currentUser before accessing props ([0aaa461](https://github.com/ciscospark/react-ciscospark/commit/0aaa461))
+* Cleanup build all script ([1a8746a](https://github.com/ciscospark/react-ciscospark/commit/1a8746a))
+* **redux-module-activity:** Fix marked cleaning process ([ebf318d](https://github.com/ciscospark/react-ciscospark/commit/ebf318d))
+* Cleanup extraneous files and missing gitignores ([937f95c](https://github.com/ciscospark/react-ciscospark/commit/937f95c))
+* **@ciscospark/react-redux-spark:** quiet the logger in production ([cf6e5aa](https://github.com/ciscospark/react-ciscospark/commit/cf6e5aa))
+* **container-file-downloader:** Remove console.log ([b65b0c3](https://github.com/ciscospark/react-ciscospark/commit/b65b0c3))
+* **container-file-downloader:** Update tests and mocks ([04072c9](https://github.com/ciscospark/react-ciscospark/commit/04072c9))
+* **demo:** Add demo to root bundle ([5bfaeab](https://github.com/ciscospark/react-ciscospark/commit/5bfaeab))
+* **demo:** load the proper widget files for demo ([338d61b](https://github.com/ciscospark/react-ciscospark/commit/338d61b))
+* **demo:** removing oauth from demo ([10ccdd3](https://github.com/ciscospark/react-ciscospark/commit/10ccdd3))
+* **metrics:** Added additional metrics, consts for names ([d2bcffa](https://github.com/ciscospark/react-ciscospark/commit/d2bcffa))
+* **package:** update [@ciscospark](https://github.com/ciscospark)/internal-plugin-conversation to version 1.11.0 ([a56073a](https://github.com/ciscospark/react-ciscospark/commit/a56073a))
+* **package:** update [@ciscospark](https://github.com/ciscospark)/plugin-people to version 1.10.4 ([a7dfe12](https://github.com/ciscospark/react-ciscospark/commit/a7dfe12))
+* **package:** update [@ciscospark](https://github.com/ciscospark)/plugin-people to version 1.12.0 ([76b9a5a](https://github.com/ciscospark/react-ciscospark/commit/76b9a5a))
+* **package:** update [@ciscospark](https://github.com/ciscospark)/plugin-phone to version 1.12.0 ([914a0c6](https://github.com/ciscospark/react-ciscospark/commit/914a0c6))
+* **package:** update core-decorators to version 0.20.0 ([6de559f](https://github.com/ciscospark/react-ciscospark/commit/6de559f))
+* **package:** update material-ui to version 0.19.4 ([8af435d](https://github.com/ciscospark/react-ciscospark/commit/8af435d)), closes [#429](https://github.com/ciscospark/react-ciscospark/issues/429)
+* **package:** update react to version 16.1.0 ([b1f071c](https://github.com/ciscospark/react-ciscospark/commit/b1f071c)), closes [#484](https://github.com/ciscospark/react-ciscospark/issues/484)
+* **package:** update react-dom to version 16.0.0 ([4cd7e75](https://github.com/ciscospark/react-ciscospark/commit/4cd7e75))
+* **package:** update react-dom to version 16.1.0 ([dd51c73](https://github.com/ciscospark/react-ciscospark/commit/dd51c73)), closes [#485](https://github.com/ciscospark/react-ciscospark/issues/485)
+* **package:** update react-draggable to version 3.0.3 ([f24c9a8](https://github.com/ciscospark/react-ciscospark/commit/f24c9a8)), closes [#438](https://github.com/ciscospark/react-ciscospark/issues/438)
+* **package:** update react-dropzone to version 4.1.3 ([c165f1b](https://github.com/ciscospark/react-ciscospark/commit/c165f1b)), closes [#396](https://github.com/ciscospark/react-ciscospark/issues/396)
+* **package:** update reselect to version 3.0.0 ([a9a94b6](https://github.com/ciscospark/react-ciscospark/commit/a9a94b6))
+* **react-component-activity-item-base:** Remove required name propType ([e2a132d](https://github.com/ciscospark/react-ciscospark/commit/e2a132d))
+* **react-component-activity-menu:** namespace css class names ([ee5546a](https://github.com/ciscospark/react-ciscospark/commit/ee5546a))
+* **react-component-avatar:** Eslint error ([993df79](https://github.com/ciscospark/react-ciscospark/commit/993df79))
+* **react-component-avatar:** size avatar-self properly ([67e7a44](https://github.com/ciscospark/react-ciscospark/commit/67e7a44))
+* **react-component-button:** Add extra specificity to button classes ([bb0dfc3](https://github.com/ciscospark/react-ciscospark/commit/bb0dfc3))
+* **react-component-button:** change key handler ([4c908d3](https://github.com/ciscospark/react-ciscospark/commit/4c908d3))
+* **react-component-button-controls:** ensure a key is provided to map ([673a746](https://github.com/ciscospark/react-ciscospark/commit/673a746))
+* **react-component-button-controls:** remove manual assignment of a11y label ([891880d](https://github.com/ciscospark/react-ciscospark/commit/891880d))
+* **react-component-icon:** use specific classname ([12a140b](https://github.com/ciscospark/react-ciscospark/commit/12a140b))
+* **react-component-people-list:** Fix onItemClick binding ([cb2ac0f](https://github.com/ciscospark/react-ciscospark/commit/cb2ac0f))
+* **react-component-ringtone:** Add try/catch for creating audio ([adcecc6](https://github.com/ciscospark/react-ciscospark/commit/adcecc6))
+* **react-component-spark-fonts:** remove unreferenced fonts ([34bc17f](https://github.com/ciscospark/react-ciscospark/commit/34bc17f))
+* **react-component-spark-fonts:** remove wrapper component ([cf7d79e](https://github.com/ciscospark/react-ciscospark/commit/cf7d79e))
+* **react-component-system-message:** Move messages to separate file ([2674828](https://github.com/ciscospark/react-ciscospark/commit/2674828))
+* **react-component-utils:** Disable metrics ([7b4f948](https://github.com/ciscospark/react-ciscospark/commit/7b4f948))
+* **react-component-utils:** rename uuid utils to not conflict with uuid package ([b4d6123](https://github.com/ciscospark/react-ciscospark/commit/b4d6123))
+* **react-component-video:** Change prop names ([b4d0c3b](https://github.com/ciscospark/react-ciscospark/commit/b4d0c3b))
+* **react-component-video:** Remove video muted props ([591eadc](https://github.com/ciscospark/react-ciscospark/commit/591eadc))
+* **react-container-activity-list:** Add whitelist for activity types ([d14b6be](https://github.com/ciscospark/react-ciscospark/commit/d14b6be))
+* **react-container-file-downloader:** Update browser-saveas to file-saver ([8d1a75a](https://github.com/ciscospark/react-ciscospark/commit/8d1a75a))
+* **react-container-file-uploader:** Ensure button is clickable ([54a9e3b](https://github.com/ciscospark/react-ciscospark/commit/54a9e3b))
+* **react-container-message-composer:** Add timeout for stop typing ([9598459](https://github.com/ciscospark/react-ciscospark/commit/9598459))
+* **react-container-message-composer:** Do not send event on every keypress ([a173577](https://github.com/ciscospark/react-ciscospark/commit/a173577))
+* **react-container-message-composer:** Fix failing tests ([4ee63f9](https://github.com/ciscospark/react-ciscospark/commit/4ee63f9))
+* **react-container-message-composer:** Hide current user in mention suggestions ([702aeea](https://github.com/ciscospark/react-ciscospark/commit/702aeea))
+* **react-container-message-composer:** Spacing issues ([479b3af](https://github.com/ciscospark/react-ciscospark/commit/479b3af))
+* **react-container-notifications:** Fix addEventListener ([1286f3f](https://github.com/ciscospark/react-ciscospark/commit/1286f3f))
+* **react-container-read-receipts:** fix participants selector being immutable aware ([0256dfc](https://github.com/ciscospark/react-ciscospark/commit/0256dfc))
+* **react-container-read-receipts:** fix slice props ([1ef32cd](https://github.com/ciscospark/react-ciscospark/commit/1ef32cd))
+* **react-container-read-receipts:** fix vertical stacking of read receipts ([0f542e6](https://github.com/ciscospark/react-ciscospark/commit/0f542e6))
+* **react-redux-spark:** Export correct HOC ([576a918](https://github.com/ciscospark/react-ciscospark/commit/576a918))
+* **react-redux-spark:** stop attempting to register on failure ([46facec](https://github.com/ciscospark/react-ciscospark/commit/46facec))
+* **react-redux-spark-metrics:** Order of props override ([aba9869](https://github.com/ciscospark/react-ciscospark/commit/aba9869))
+* **redux-mmodule-mercury:** Fix metric typo ([638e31b](https://github.com/ciscospark/react-ciscospark/commit/638e31b))
+* **redux-module-activity:** add support for empty strings in #createMessageObject ([e014735](https://github.com/ciscospark/react-ciscospark/commit/e014735))
+* **redux-module-activity:** clear typing indicator when sending activity ([0a9d81c](https://github.com/ciscospark/react-ciscospark/commit/0a9d81c))
+* **redux-module-activity:** Fix sending messages with html ([0613337](https://github.com/ciscospark/react-ciscospark/commit/0613337))
+* **redux-module-avatar:** Avatar storage and retrieval issue ([c122423](https://github.com/ciscospark/react-ciscospark/commit/c122423))
+* **redux-module-avatar:** Redefine direct space with 2 participants ([8818581](https://github.com/ciscospark/react-ciscospark/commit/8818581))
+* **redux-module-conversation:** add param to previous message load ([27f8f82](https://github.com/ciscospark/react-ciscospark/commit/27f8f82))
+* **redux-module-conversation:** call computeRoomProperties on create ([bcc6c32](https://github.com/ciscospark/react-ciscospark/commit/bcc6c32))
+* **redux-module-conversation:** fix acknowledge activity to use immutable for participants ([841d7b7](https://github.com/ciscospark/react-ciscospark/commit/841d7b7))
+* **redux-module-conversation:** fix and use updateConversationState ([3631046](https://github.com/ciscospark/react-ciscospark/commit/3631046))
+* **redux-module-conversation:** Remove extraneous state ([cab995e](https://github.com/ciscospark/react-ciscospark/commit/cab995e))
+* **redux-module-conversation:** Remove single participant drops more than one ([f39667a](https://github.com/ciscospark/react-ciscospark/commit/f39667a))
+* **redux-module-errors:** change to proper name #addError ([9619418](https://github.com/ciscospark/react-ciscospark/commit/9619418))
+* **redux-module-errors:** fix hasError calculation ([6375ab6](https://github.com/ciscospark/react-ciscospark/commit/6375ab6))
+* **redux-module-errors:** fix hasError calculation ([cd7b65c](https://github.com/ciscospark/react-ciscospark/commit/cd7b65c))
+* **redux-module-flags:** Fix tests and broken immutable getters ([0b469a4](https://github.com/ciscospark/react-ciscospark/commit/0b469a4))
+* **redux-module-flags:** Fixed extraneous then ([3789c1f](https://github.com/ciscospark/react-ciscospark/commit/3789c1f))
+* **redux-module-media:** Add returns to thunks ([181e1d8](https://github.com/ciscospark/react-ciscospark/commit/181e1d8))
+* **redux-module-media:** Adjust status name ([40f7cc0](https://github.com/ciscospark/react-ciscospark/commit/40f7cc0))
+* **redux-module-media:** Call decline immedately declines call ([adfc6f8](https://github.com/ciscospark/react-ciscospark/commit/adfc6f8))
+* **redux-module-media:** compute activeParticipantsCount for call state ([a186d23](https://github.com/ciscospark/react-ciscospark/commit/a186d23))
+* **redux-module-media:** Convert prop to object ([838942f](https://github.com/ciscospark/react-ciscospark/commit/838942f))
+* **redux-module-media:** Fix calling not recieving remote media ([1a16015](https://github.com/ciscospark/react-ciscospark/commit/1a16015))
+* **redux-module-media:** Fix eslint error and connect event listeners ([f3c7a62](https://github.com/ciscospark/react-ciscospark/commit/f3c7a62))
+* **redux-module-media:** Fix event firing order for local self view display ([574f052](https://github.com/ciscospark/react-ciscospark/commit/574f052))
+* **redux-module-media:** Locus id to locus url ([71f1a87](https://github.com/ciscospark/react-ciscospark/commit/71f1a87))
+* **redux-module-media:** Maintain webRTC isSupported state ([7640c72](https://github.com/ciscospark/react-ciscospark/commit/7640c72))
+* **redux-module-media:** pass proper offer options to call object ([b98136a](https://github.com/ciscospark/react-ciscospark/commit/b98136a))
+* **redux-module-media:** properly get current state on incoming call ([aa817f3](https://github.com/ciscospark/react-ciscospark/commit/aa817f3))
+* **redux-module-media:** Release camera on call failure ([77102bd](https://github.com/ciscospark/react-ciscospark/commit/77102bd))
+* **redux-module-media:** smarter local media stream handling ([13148a0](https://github.com/ciscospark/react-ciscospark/commit/13148a0))
+* **redux-module-media:** Split audio and video tracks to fix video mute ([8cf55f7](https://github.com/ciscospark/react-ciscospark/commit/8cf55f7))
+* **redux-module-media:** store call once we have a locus ([23084ec](https://github.com/ciscospark/react-ciscospark/commit/23084ec))
+* **redux-module-mercury:** Return on thunk ([159738b](https://github.com/ciscospark/react-ciscospark/commit/159738b))
+* **redux-module-presence:** fix eslint errors ([0c267b9](https://github.com/ciscospark/react-ciscospark/commit/0c267b9))
+* **redux-module-spaces:** add support for directs with deleted users ([4aa898d](https://github.com/ciscospark/react-ciscospark/commit/4aa898d))
+* **redux-module-spaces:** eslint and jsdoc fixes ([487a145](https://github.com/ciscospark/react-ciscospark/commit/487a145))
+* **redux-module-spaces:** sort space results before getting the oldest ([09b8cd8](https://github.com/ciscospark/react-ciscospark/commit/09b8cd8))
+* **redux-module-teams:** Fix wrong action names ([557501a](https://github.com/ciscospark/react-ciscospark/commit/557501a))
+* **redux-module-teams:** Prevent infinite team fetching ([fcbf871](https://github.com/ciscospark/react-ciscospark/commit/fcbf871))
+* **redux-module-user:** Make metric name uniform ([c5ce5bb](https://github.com/ciscospark/react-ciscospark/commit/c5ce5bb))
+* **space-widget:** Fix bad element reference and remove unused component ([4884b7f](https://github.com/ciscospark/react-ciscospark/commit/4884b7f))
+* **spark-widget-base:** Create new store on each widget instance ([266fd53](https://github.com/ciscospark/react-ciscospark/commit/266fd53))
+* **spark-widget-base:** Do not remove clear on unmount ([f3566a1](https://github.com/ciscospark/react-ciscospark/commit/f3566a1))
+* **tap:** widget message meet cannot use meet helper functions ([1d529a0](https://github.com/ciscospark/react-ciscospark/commit/1d529a0))
+* **tests:** Fix wmm journey test ([5cd9a8f](https://github.com/ciscospark/react-ciscospark/commit/5cd9a8f))
+* **tooling:** Add html build step, version to file header, global use strict ([0a41404](https://github.com/ciscospark/react-ciscospark/commit/0a41404))
+* **tooling:** Add node 7 install to tap tests ([bec42bf](https://github.com/ciscospark/react-ciscospark/commit/bec42bf))
+* **tooling:** Add node_env back to build commands ([cbf06d0](https://github.com/ciscospark/react-ciscospark/commit/cbf06d0))
+* **tooling:** Add rebuild to tap tests ([972d6b1](https://github.com/ciscospark/react-ciscospark/commit/972d6b1))
+* **tooling:** Add spark-widget-base to jest config ([ca505ad](https://github.com/ciscospark/react-ciscospark/commit/ca505ad))
+* **tooling:** Add utc TZ to jest tests ([e8377c8](https://github.com/ciscospark/react-ciscospark/commit/e8377c8))
+* **tooling:** Build output target issue ([511a5f9](https://github.com/ciscospark/react-ciscospark/commit/511a5f9))
+* **tooling:** Chnage stylelint config to js ([af188fb](https://github.com/ciscospark/react-ciscospark/commit/af188fb))
+* **tooling:** Clean build scripts, update Jenkinsfile ([8da1869](https://github.com/ciscospark/react-ciscospark/commit/8da1869))
+* **tooling:** Clean local tags when building ([ef90800](https://github.com/ciscospark/react-ciscospark/commit/ef90800))
+* **tooling:** Copy non-js files correctly on build ([32bf054](https://github.com/ciscospark/react-ciscospark/commit/32bf054))
+* **tooling:** Fix circle npm install ([958a360](https://github.com/ciscospark/react-ciscospark/commit/958a360))
+* **tooling:** Fix circle tests ([548a40e](https://github.com/ciscospark/react-ciscospark/commit/548a40e))
+* **tooling:** Fix credentials ([d7dac40](https://github.com/ciscospark/react-ciscospark/commit/d7dac40))
+* **tooling:** Fix git version bumping ([049a5ff](https://github.com/ciscospark/react-ciscospark/commit/049a5ff))
+* **tooling:** Fix jenkinsfile syntax ([7499332](https://github.com/ciscospark/react-ciscospark/commit/7499332))
+* **tooling:** Fix jenkinsfile syntax take 2 ([7a9a322](https://github.com/ciscospark/react-ciscospark/commit/7a9a322))
+* **tooling:** Fix moment build, add react-intl ([a869dc0](https://github.com/ciscospark/react-ciscospark/commit/a869dc0))
+* **tooling:** Fix syntax issue ([f2b8a0c](https://github.com/ciscospark/react-ciscospark/commit/f2b8a0c))
+* **tooling:** Fix test user missing access token ([2b4b7e5](https://github.com/ciscospark/react-ciscospark/commit/2b4b7e5))
+* **tooling:** Fix test user missing access token ([b71a9aa](https://github.com/ciscospark/react-ciscospark/commit/b71a9aa))
+* **tooling:** Fix transpile and postcss script ([e759bde](https://github.com/ciscospark/react-ciscospark/commit/e759bde))
+* **tooling:** Force git to reset and clean directory ([502eda8](https://github.com/ciscospark/react-ciscospark/commit/502eda8))
+* **tooling:** Jenkins version bump variables ([10bb90a](https://github.com/ciscospark/react-ciscospark/commit/10bb90a))
+* **tooling:** Jenkinsfile remove NPM_CONFIG_REGISTRY ([bb981e5](https://github.com/ciscospark/react-ciscospark/commit/bb981e5))
+* **tooling:** Jenkinsfile remove npmrc after install ([d2a5d1b](https://github.com/ciscospark/react-ciscospark/commit/d2a5d1b))
+* **tooling:** Move jenkinsfile.tap to procedural groovy ([241b5fb](https://github.com/ciscospark/react-ciscospark/commit/241b5fb))
+* **tooling:** Move jsnext:main to module in package.json ([c407e46](https://github.com/ciscospark/react-ciscospark/commit/c407e46))
+* **tooling:** Move redux-logger to main dep, add sri-toolbox ([488ade3](https://github.com/ciscospark/react-ciscospark/commit/488ade3))
+* **tooling:** Patch for babel transform runtime bug ([ac6a069](https://github.com/ciscospark/react-ciscospark/commit/ac6a069))
+* **tooling:** Point to correct CDN location ([ca7c820](https://github.com/ciscospark/react-ciscospark/commit/ca7c820))
+* **tooling:** Remove npm rebuild from tap scripts ([5b189bd](https://github.com/ciscospark/react-ciscospark/commit/5b189bd))
+* **tooling:** Reset all package package.json files" ([5e77e7e](https://github.com/ciscospark/react-ciscospark/commit/5e77e7e))
+* **tooling:** Tweak dev server, add fonts to icon ([3a3f10e](https://github.com/ciscospark/react-ciscospark/commit/3a3f10e))
+* **tooling:** Update deps, eslint-config still an issue ([0267bdf](https://github.com/ciscospark/react-ciscospark/commit/0267bdf))
+* **tooling:** Update stylelint ([e6d00b9](https://github.com/ciscospark/react-ciscospark/commit/e6d00b9))
+* **tooling:** Update transpile script to use babel-preset-env ([693d98d](https://github.com/ciscospark/react-ciscospark/commit/693d98d))
+* **tooling:** Update unused release.sh ([4743f20](https://github.com/ciscospark/react-ciscospark/commit/4743f20))
+* **tooling:** Whitelist env vars ([e6c1c15](https://github.com/ciscospark/react-ciscospark/commit/e6c1c15))
+* **tools:** add NODE_ENV var to start script ([3a14ba4](https://github.com/ciscospark/react-ciscospark/commit/3a14ba4))
+* **widget-base:** Add correct name detection ([ff947d9](https://github.com/ciscospark/react-ciscospark/commit/ff947d9))
+* **widget-base:** Add spark reducer as default ([9fd6373](https://github.com/ciscospark/react-ciscospark/commit/9fd6373))
+* **widget-base:** Broken Safari data-api ([9c23554](https://github.com/ciscospark/react-ciscospark/commit/9c23554))
+* **widget-base:** Change console.warning to console.warn ([4762217](https://github.com/ciscospark/react-ciscospark/commit/4762217))
+* **widget-base:** Fix initial store load when using ReactComponent ([5b01ae2](https://github.com/ciscospark/react-ciscospark/commit/5b01ae2))
+* **widget-base:** Fix message-composer being blocked in Safari ([0bd6b0f](https://github.com/ciscospark/react-ciscospark/commit/0bd6b0f))
+* **widget-base:** Fix onEvent calling ([9ec0bb4](https://github.com/ciscospark/react-ciscospark/commit/9ec0bb4))
+* **widget-base:** Init new store for every top level widget ([afb205d](https://github.com/ciscospark/react-ciscospark/commit/afb205d))
+* **widget-base:** Inject wrapper class if necessary ([99694c0](https://github.com/ciscospark/react-ciscospark/commit/99694c0))
+* **widget-base:** Minor changes based on feedback ([43c97f6](https://github.com/ciscospark/react-ciscospark/commit/43c97f6))
+* **widget-base:** Remove amp events when widget is removed ([87c745a](https://github.com/ciscospark/react-ciscospark/commit/87c745a))
+* **widget-base:** Remove bad merge ([05e581d](https://github.com/ciscospark/react-ciscospark/commit/05e581d))
+* **widget-base:** Remove old metrics, fix init timing issue ([8bb4d72](https://github.com/ciscospark/react-ciscospark/commit/8bb4d72))
+* **widget-base:** Remove unused localStorageAdapter ([165fa22](https://github.com/ciscospark/react-ciscospark/commit/165fa22))
+* **widget-base:** return unmount status during .remove() ([e2c25a0](https://github.com/ciscospark/react-ciscospark/commit/e2c25a0))
+* **widget-base:** Update createLogger ([fc0f62b](https://github.com/ciscospark/react-ciscospark/commit/fc0f62b))
+* **widget-meet:** add call from data on incoming call ([27bd414](https://github.com/ciscospark/react-ciscospark/commit/27bd414))
+* **widget-meet:** All StartCall prop to accept string value ([47df59f](https://github.com/ciscospark/react-ciscospark/commit/47df59f))
+* **widget-meet:** capitalize accessibility labels for control buttons ([59027ec](https://github.com/ciscospark/react-ciscospark/commit/59027ec))
+* **widget-meet:** Disable eslint complexity rule ([f764412](https://github.com/ciscospark/react-ciscospark/commit/f764412))
+* **widget-meet:** Do not display controls until call object is available ([6036514](https://github.com/ciscospark/react-ciscospark/commit/6036514))
+* **widget-meet:** emit proper disconnect event ([90c37ca](https://github.com/ciscospark/react-ciscospark/commit/90c37ca))
+* **widget-meet:** fix display of incoming call and inactive call components at same time ([6d1447a](https://github.com/ciscospark/react-ciscospark/commit/6d1447a))
+* **widget-meet:** Fix start call flag ([e4d3439](https://github.com/ciscospark/react-ciscospark/commit/e4d3439))
+* **widget-meet:** Fix webrtc detection in safari ([6ef3bac](https://github.com/ciscospark/react-ciscospark/commit/6ef3bac))
+* **widget-meet:** Fix wrong PropType ([62a4119](https://github.com/ciscospark/react-ciscospark/commit/62a4119))
+* **widget-meet:** Force mute buttons active until connect ([0684d6b](https://github.com/ciscospark/react-ciscospark/commit/0684d6b))
+* **widget-meet:** hangup on unmount ([801d83d](https://github.com/ciscospark/react-ciscospark/commit/801d83d))
+* **widget-meet:** keep video component in dom when video muted ([2cfb9ea](https://github.com/ciscospark/react-ciscospark/commit/2cfb9ea))
+* **widget-meet:** Listen to incoming messages ([5ec20b8](https://github.com/ciscospark/react-ciscospark/commit/5ec20b8))
+* **widget-meet:** load space avatar from avatars store ([dcb9bda](https://github.com/ciscospark/react-ciscospark/commit/dcb9bda))
+* **widget-meet:** remove check for button state ([ca19da7](https://github.com/ciscospark/react-ciscospark/commit/ca19da7))
+* **widget-meet:** space calling should go to hydra id ([870d984](https://github.com/ciscospark/react-ciscospark/commit/870d984))
+* **widget-meet:** Update messaging ([ea81e26](https://github.com/ciscospark/react-ciscospark/commit/ea81e26))
+* **widget-meet:** Update sdk to get facing mode fix ([a50f18c](https://github.com/ciscospark/react-ciscospark/commit/a50f18c))
+* **widget-message:** Add check for buffer state listener ([afd0a62](https://github.com/ciscospark/react-ciscospark/commit/afd0a62))
+* **widget-message:** add detail is listening flags ([47de0f4](https://github.com/ciscospark/react-ciscospark/commit/47de0f4))
+* **widget-message:** Add getFeature method ([067833c](https://github.com/ciscospark/react-ciscospark/commit/067833c))
+* **widget-message:** Add getFeature to proptypes ([3bdd12a](https://github.com/ciscospark/react-ciscospark/commit/3bdd12a))
+* **widget-message:** bind handle flag action ([45e4e60](https://github.com/ciscospark/react-ciscospark/commit/45e4e60))
+* **widget-message:** Blank name in message composer ([ff3888a](https://github.com/ciscospark/react-ciscospark/commit/ff3888a))
+* **widget-message:** change to use widgetMessage props ([89f3301](https://github.com/ciscospark/react-ciscospark/commit/89f3301))
+* **widget-message:** Check for activity before test ([bafd1ad](https://github.com/ciscospark/react-ciscospark/commit/bafd1ad))
+* **widget-message:** Do not display message composer until conversation is loaded ([688199f](https://github.com/ciscospark/react-ciscospark/commit/688199f))
+* **widget-message:** Do not fire messages:unread when this user sends ([ea646c6](https://github.com/ciscospark/react-ciscospark/commit/ea646c6))
+* **widget-message:** Fix at mention structure and proptype ([0bf82a4](https://github.com/ciscospark/react-ciscospark/commit/0bf82a4))
+* **widget-message:** Fix overwriting issue with target id ([9d00b89](https://github.com/ciscospark/react-ciscospark/commit/9d00b89))
+* **widget-message:** Fix style issue in composer ([8aeee50](https://github.com/ciscospark/react-ciscospark/commit/8aeee50))
+* **widget-message:** get immutable widget properties properly ([58213b2](https://github.com/ciscospark/react-ciscospark/commit/58213b2))
+* **widget-message:** handle empty toUser ([fb348c7](https://github.com/ciscospark/react-ciscospark/commit/fb348c7))
+* **widget-message:** Load history scroll not sticking ([238fa61](https://github.com/ciscospark/react-ciscospark/commit/238fa61))
+* **widget-message:** Move messages:created to before rooms:unread ([23d5612](https://github.com/ciscospark/react-ciscospark/commit/23d5612))
+* **widget-message:** Move props to selector, fix text placeholder ([c529dc8](https://github.com/ciscospark/react-ciscospark/commit/c529dc8))
+* **widget-message:** remove empty notification of locus events ([ccf80cb](https://github.com/ciscospark/react-ciscospark/commit/ccf80cb))
+* **widget-message:** store current user id outside event block ([4972c05](https://github.com/ciscospark/react-ciscospark/commit/4972c05))
+* **widget-message:** Wait for device registration before createconvo ([a1b6665](https://github.com/ciscospark/react-ciscospark/commit/a1b6665))
+* **widget-message-meet:** Add border-box, fix title bar overlap ([cd0232f](https://github.com/ciscospark/react-ciscospark/commit/cd0232f))
+* **widget-message-meet:** Add eslint ignore for complexity ([4f1da96](https://github.com/ciscospark/react-ciscospark/commit/4f1da96))
+* **widget-message-meet:** Allow conversation with user with no account ([fd75c39](https://github.com/ciscospark/react-ciscospark/commit/fd75c39))
+* **widget-message-meet:** Check for required data before load ([589165b](https://github.com/ciscospark/react-ciscospark/commit/589165b))
+* **widget-message-meet:** Compile issue causes global class issue ([1096502](https://github.com/ciscospark/react-ciscospark/commit/1096502))
+* **widget-message-meet:** display only one widget in demo ([823e67d](https://github.com/ciscospark/react-ciscospark/commit/823e67d))
+* **widget-message-meet:** Fix auth issue and adjusted styles ([2947835](https://github.com/ciscospark/react-ciscospark/commit/2947835))
+* **widget-message-meet:** fix bad merge and misspelling ([d1d7d2e](https://github.com/ciscospark/react-ciscospark/commit/d1d7d2e))
+* **widget-message-meet:** Fix style issues in FF, and proptypes errors ([5da911c](https://github.com/ciscospark/react-ciscospark/commit/5da911c))
+* **widget-message-meet:** Move checks to allow more parallel requests ([e59eac0](https://github.com/ciscospark/react-ciscospark/commit/e59eac0))
+* **widget-message-meet:** pass proper property to meet ([493119a](https://github.com/ciscospark/react-ciscospark/commit/493119a))
+* **widget-message-meet:** properly load avatar in title bar ([bf97a13](https://github.com/ciscospark/react-ciscospark/commit/bf97a13))
+* **widget-message-meet:** Revert container to just message widget" ([1e2ac73](https://github.com/ciscospark/react-ciscospark/commit/1e2ac73))
+* **widget-message-meet:** Switch to meet on incoming call ([eada7e7](https://github.com/ciscospark/react-ciscospark/commit/eada7e7))
+* **widget-message-meet-demo:** clear token cookie properly ([2fc0df7](https://github.com/ciscospark/react-ciscospark/commit/2fc0df7))
+* **widget-recents:** Add recents to jenkinsfile, toJS fix ([a3249c3](https://github.com/ciscospark/react-ciscospark/commit/a3249c3))
+* **widget-recents:** Correct event removal issue on incoming calls ([ae5af79](https://github.com/ciscospark/react-ciscospark/commit/ae5af79))
+* **widget-recents:** delete incoming call when connected ([a5d867d](https://github.com/ciscospark/react-ciscospark/commit/a5d867d))
+* **widget-recents:** Do not mark rooms user sent message in as unread ([9139906](https://github.com/ciscospark/react-ciscospark/commit/9139906))
+* **widget-recents:** Fix complexity eslit error ([7c1f210](https://github.com/ciscospark/react-ciscospark/commit/7c1f210))
+* **widget-recents:** Fix membership:created event ([a9ec826](https://github.com/ciscospark/react-ciscospark/commit/a9ec826))
+* **widget-recents:** Fix space click bug ([bb5dcdf](https://github.com/ciscospark/react-ciscospark/commit/bb5dcdf))
+* **widget-recents:** Fix space name split error ([58b0988](https://github.com/ciscospark/react-ciscospark/commit/58b0988))
+* **widget-recents:** Prevent call button for group spaces ([1161eb0](https://github.com/ciscospark/react-ciscospark/commit/1161eb0))
+* **widget-recents:** Prevent stack range error on call logger ([1952ed3](https://github.com/ciscospark/react-ciscospark/commit/1952ed3))
+* **widget-recents:** Rearranged action/reducer order, add jsdocs ([2d7eda4](https://github.com/ciscospark/react-ciscospark/commit/2d7eda4))
+* **widget-recents:** Remove no-enter keypresses for selecting space ([e7b7ff5](https://github.com/ciscospark/react-ciscospark/commit/e7b7ff5))
+* **widget-recents:** Show unread indicator when space has never been seen ([2b35b7a](https://github.com/ciscospark/react-ciscospark/commit/2b35b7a))
+* **widget-recents:** support for untitled rooms ([9c65a8b](https://github.com/ciscospark/react-ciscospark/commit/9c65a8b))
+* **widget-roster:** fix name of the roster from incorrect 'message' ([6f79d1e](https://github.com/ciscospark/react-ciscospark/commit/6f79d1e)), closes [#565](https://github.com/ciscospark/react-ciscospark/issues/565)
+* **widget-roster:** fix sort method and check for room properties ([a778f6c](https://github.com/ciscospark/react-ciscospark/commit/a778f6c))
+* **widget-roster:** Remove unused PropType ([8ed8418](https://github.com/ciscospark/react-ciscospark/commit/8ed8418))
+* **widget-space:** Add higher specificity to button style ([598b7e5](https://github.com/ciscospark/react-ciscospark/commit/598b7e5))
+* **widget-space:** Add internal propType to prop filter ([79874ab](https://github.com/ciscospark/react-ciscospark/commit/79874ab))
+* **widget-space:** Add jsdocs, fix test ([4b43842](https://github.com/ciscospark/react-ciscospark/commit/4b43842))
+* **widget-space:** Allow closing of activity menu from sub widget ([b5c0651](https://github.com/ciscospark/react-ciscospark/commit/b5c0651))
+* **widget-space:** Allow closing of activity menu from sub widget ([db905f9](https://github.com/ciscospark/react-ciscospark/commit/db905f9))
+* **widget-space:** Allow user to call when direct spaceID is provided ([ee6a3d1](https://github.com/ciscospark/react-ciscospark/commit/ee6a3d1))
+* **widget-space:** Ensure correct activity is initially loaded ([0de8b78](https://github.com/ciscospark/react-ciscospark/commit/0de8b78))
+* **widget-space:** Fix eslint error ([c85e6ee](https://github.com/ciscospark/react-ciscospark/commit/c85e6ee))
+* **widget-space:** Fix incoming calls not working ([7d75acc](https://github.com/ciscospark/react-ciscospark/commit/7d75acc))
+* **widget-space:** Fix initialActivity setting with data-api ([7efa831](https://github.com/ciscospark/react-ciscospark/commit/7efa831))
+* **widget-space:** Fix style issue on containers ([f56af28](https://github.com/ciscospark/react-ciscospark/commit/f56af28))
+* **widget-space:** Fixed styles to correctly display activity widget ([9ae76d9](https://github.com/ciscospark/react-ciscospark/commit/9ae76d9))
+* **widget-space:** load space avatar properly ([8bf9ca8](https://github.com/ciscospark/react-ciscospark/commit/8bf9ca8))
+* **widget-space:** prop typo for initialActivity ([9b1a1b0](https://github.com/ciscospark/react-ciscospark/commit/9b1a1b0))
+* **widget-space:** return to message view after call ([26ad8d6](https://github.com/ciscospark/react-ciscospark/commit/26ad8d6))
+* **widget-space:** Revert test template ([a337cbf](https://github.com/ciscospark/react-ciscospark/commit/a337cbf))
+* **widget-space:** Switch to message view after call hangup ([4edc4d4](https://github.com/ciscospark/react-ciscospark/commit/4edc4d4))
+* **widget-space:** UI fixes and API changes ([e56d633](https://github.com/ciscospark/react-ciscospark/commit/e56d633))
+* **widget-space-demo:** Fix package name collision ([f1aeada](https://github.com/ciscospark/react-ciscospark/commit/f1aeada))
+* eslint errors and jest tests from presence merge ([114a1bf](https://github.com/ciscospark/react-ciscospark/commit/114a1bf))
+* fix some lint errors with eslint --fix ([b5ac837](https://github.com/ciscospark/react-ciscospark/commit/b5ac837))
+* gitattributes? ([a2784a0](https://github.com/ciscospark/react-ciscospark/commit/a2784a0))
+* Jest tests, move to in memory object for metrics storage ([6062284](https://github.com/ciscospark/react-ciscospark/commit/6062284))
+* remove extra eslint-disable and fix errors ([562a99c](https://github.com/ciscospark/react-ciscospark/commit/562a99c))
+* Remove extraneous required proptypes ([916fe03](https://github.com/ciscospark/react-ciscospark/commit/916fe03))
+* removing workaround for redux-logger ([fcdcd90](https://github.com/ciscospark/react-ciscospark/commit/fcdcd90))
+* **widget-space-demo:** handle mode toggle properly ([a3557b4](https://github.com/ciscospark/react-ciscospark/commit/a3557b4))
+* **widget-space-demo:** only pass property of selected mode ([0ef2032](https://github.com/ciscospark/react-ciscospark/commit/0ef2032))
+* static method errors ([d9a0e99](https://github.com/ciscospark/react-ciscospark/commit/d9a0e99))
+* Temporarily remove default props for certain objects ([7134dee](https://github.com/ciscospark/react-ciscospark/commit/7134dee))
+
+
+### Features
+
+* **redux-module-avatar:** check state before starting request ([e7b8128](https://github.com/ciscospark/react-ciscospark/commit/e7b8128))
+* Components now build ([0426d8e](https://github.com/ciscospark/react-ciscospark/commit/0426d8e))
+* **all:** add iconSize prop to PresenceAvatar implementations ([105a0c5](https://github.com/ciscospark/react-ciscospark/commit/105a0c5))
+* **call-activity:** display locus call data in activity list ([886b7d8](https://github.com/ciscospark/react-ciscospark/commit/886b7d8))
+* **components:** Add all activity list components ([caa1e42](https://github.com/ciscospark/react-ciscospark/commit/caa1e42))
+* **components:** Add chip, modal, staging area, sparators, and utils ([2ff6707](https://github.com/ciscospark/react-ciscospark/commit/2ff6707))
+* **components:** Add loading-screen and spinner ([f3db512](https://github.com/ciscospark/react-ciscospark/commit/f3db512))
+* **components:** Add new message separator, fix tests ([c358b71](https://github.com/ciscospark/react-ciscospark/commit/c358b71))
+* **components:** Add redux wrapper, activity items ([17ed13a](https://github.com/ciscospark/react-ciscospark/commit/17ed13a))
+* **components:** Add scroll to bottom button ([fc3d90b](https://github.com/ciscospark/react-ciscospark/commit/fc3d90b))
+* **components:** Add text area component ([aa96b9a](https://github.com/ciscospark/react-ciscospark/commit/aa96b9a))
+* **components:** Add TitleBar component ([0a0e776](https://github.com/ciscospark/react-ciscospark/commit/0a0e776))
+* **components:** Add typingAvatar and typingIndicator components ([9fab467](https://github.com/ciscospark/react-ciscospark/commit/9fab467))
+* **components:** All components migrated. Tests updated. Some tests still failing ([537c49e](https://github.com/ciscospark/react-ciscospark/commit/537c49e))
+* **demo:** add material-ui styling ([666af8c](https://github.com/ciscospark/react-ciscospark/commit/666af8c))
+* **demo:** add message meet widget to demo ([2d8ea1a](https://github.com/ciscospark/react-ciscospark/commit/2d8ea1a))
+* **demo:** change example to tabbed view ([aaf1a73](https://github.com/ciscospark/react-ciscospark/commit/aaf1a73))
+* **demo:** demo login moved into its own component ([6e559e8](https://github.com/ciscospark/react-ciscospark/commit/6e559e8))
+* **demo:** initial router setup ([b58c84e](https://github.com/ciscospark/react-ciscospark/commit/b58c84e))
+* **demos:** use new react-cookies methods ([dde832d](https://github.com/ciscospark/react-ciscospark/commit/dde832d))
+* **metrics:** Add store for metrics that aren't ready to be sent ([0e01e13](https://github.com/ciscospark/react-ciscospark/commit/0e01e13))
+* **r-comp-activity-system-message:** add group call messages ([377df5e](https://github.com/ciscospark/react-ciscospark/commit/377df5e))
+* **react-component-activity-item:** support for error activity retries ([3b2828b](https://github.com/ciscospark/react-ciscospark/commit/3b2828b))
+* **react-component-activity-item-base:** add support for error activity retries ([2b56a78](https://github.com/ciscospark/react-ciscospark/commit/2b56a78))
+* **react-component-activity-item-base:** build classes array for avatar classes ([e07d7aa](https://github.com/ciscospark/react-ciscospark/commit/e07d7aa))
+* **react-component-activity-item-base:** display name "you" for self activities ([c40ab9a](https://github.com/ciscospark/react-ciscospark/commit/c40ab9a))
+* **react-component-activity-item-base:** implement avatar size ([666fd67](https://github.com/ciscospark/react-ciscospark/commit/666fd67))
+* **react-component-activity-item-base:** Show publish time without hover ([aab26c7](https://github.com/ciscospark/react-ciscospark/commit/aab26c7))
+* **react-component-activity-item-base:** use PresenceAvatar component ([28320a7](https://github.com/ciscospark/react-ciscospark/commit/28320a7))
+* **react-component-activity-list:** add support for group call data parsing ([459d8ae](https://github.com/ciscospark/react-ciscospark/commit/459d8ae))
+* **react-component-activity-list:** add support for roster events ([2467264](https://github.com/ciscospark/react-ciscospark/commit/2467264))
+* **react-component-activity-list:** pass actorId instead of avatar ([9620c09](https://github.com/ciscospark/react-ciscospark/commit/9620c09))
+* **react-component-activity-list:** remove callData prop ([8aac635](https://github.com/ciscospark/react-ciscospark/commit/8aac635))
+* **react-component-activity-list:** support for error activity retries ([51889e2](https://github.com/ciscospark/react-ciscospark/commit/51889e2))
+* **react-component-activity-menu:** initial component creation ([1f4622d](https://github.com/ciscospark/react-ciscospark/commit/1f4622d))
+* **react-component-activity-menu:** style the menu appropriately ([a9630cd](https://github.com/ciscospark/react-ciscospark/commit/a9630cd))
+* **react-component-activity-system-message:** add support for roster events ([05747f3](https://github.com/ciscospark/react-ciscospark/commit/05747f3))
+* **react-component-activity-system-message:** use CallDataActivityMessage ([be77c7d](https://github.com/ciscospark/react-ciscospark/commit/be77c7d))
+* **react-component-activity-text:** Add html filter on dangerously set html ([1c056a8](https://github.com/ciscospark/react-ciscospark/commit/1c056a8))
+* **react-component-activity-text:** add pre-wrap style for new lines ([61cc206](https://github.com/ciscospark/react-ciscospark/commit/61cc206))
+* **react-component-activity-text:** use linkify to create links for text ([3426a60](https://github.com/ciscospark/react-ciscospark/commit/3426a60))
+* **react-component-audio:** New audio component that supports srcObject ([6ca9d35](https://github.com/ciscospark/react-ciscospark/commit/6ca9d35))
+* **react-component-avatar:** add conversion to uppercase for names ([e8e70e5](https://github.com/ciscospark/react-ciscospark/commit/e8e70e5))
+* **react-component-avatar:** add size prop to avatar ([2e27f7b](https://github.com/ciscospark/react-ciscospark/commit/2e27f7b))
+* **react-component-badge:** add tooltip support ([85cf5f5](https://github.com/ciscospark/react-ciscospark/commit/85cf5f5))
+* **react-component-badge:** initial implementation ([875c912](https://github.com/ciscospark/react-ciscospark/commit/875c912))
+* **react-component-button:** accessibility label prop added ([cd5fe32](https://github.com/ciscospark/react-ciscospark/commit/cd5fe32))
+* **react-component-button:** accessibility label prop added ([ef89db8](https://github.com/ciscospark/react-ciscospark/commit/ef89db8))
+* **react-component-button:** add aria-label to button ([484bce6](https://github.com/ciscospark/react-ciscospark/commit/484bce6))
+* **react-component-button:** add aria-label to button ([cb649fe](https://github.com/ciscospark/react-ciscospark/commit/cb649fe))
+* **react-component-button:** use icon title as aria label ([9653abb](https://github.com/ciscospark/react-ciscospark/commit/9653abb))
+* **react-component-button-controls:** use button label as accessibility label ([8cceb2b](https://github.com/ciscospark/react-ciscospark/commit/8cceb2b))
+* **react-component-call-data-activity:** initial component ([35bd069](https://github.com/ciscospark/react-ciscospark/commit/35bd069))
+* **react-component-cover:** Create screen cover component ([8a3d42d](https://github.com/ciscospark/react-ciscospark/commit/8a3d42d))
+* **react-component-error-display:** initial implementation ([6ac79e0](https://github.com/ciscospark/react-ciscospark/commit/6ac79e0))
+* **react-component-icon:** add contact icon support ([c1b9b82](https://github.com/ciscospark/react-ciscospark/commit/c1b9b82))
+* **react-component-icon:** add dnd and pto icons ([b7101eb](https://github.com/ciscospark/react-ciscospark/commit/b7101eb))
+* **react-component-icon:** add invite icon ([2dc8a57](https://github.com/ciscospark/react-ciscospark/commit/2dc8a57))
+* **react-component-icon:** add more icon ([fe250b3](https://github.com/ciscospark/react-ciscospark/commit/fe250b3))
+* **react-component-icon:** make external user icons available ([9eb362c](https://github.com/ciscospark/react-ciscospark/commit/9eb362c))
+* **react-component-icon:** upgrade to Neo-icons font ([2340b76](https://github.com/ciscospark/react-ciscospark/commit/2340b76))
+* **react-component-incoming-call:** Moved component into package ([117cd1a](https://github.com/ciscospark/react-ciscospark/commit/117cd1a))
+* **react-component-people-list:** Create people list component ([48261d4](https://github.com/ciscospark/react-ciscospark/commit/48261d4))
+* **react-component-people-list:** use connected PresenceAvatar ([cb1d866](https://github.com/ciscospark/react-ciscospark/commit/cb1d866))
+* **react-component-person-list-item:** change avatarUrl param to avatar ([25888ec](https://github.com/ciscospark/react-ciscospark/commit/25888ec))
+* **react-component-person-list-item:** initial component ([5f4f0db](https://github.com/ciscospark/react-ciscospark/commit/5f4f0db))
+* **react-component-presence-avatar:** initial implementation ([d8efdf9](https://github.com/ciscospark/react-ciscospark/commit/d8efdf9))
+* **react-component-ringtone:** initial component ([059dec8](https://github.com/ciscospark/react-ciscospark/commit/059dec8))
+* **react-component-spark-fonts:** initial component ([a6f73e4](https://github.com/ciscospark/react-ciscospark/commit/a6f73e4))
+* **react-component-spark-logo:** initial component ([b1b0a4c](https://github.com/ciscospark/react-ciscospark/commit/b1b0a4c))
+* **react-component-spark-oauth:** create new component from demo code ([7c13acc](https://github.com/ciscospark/react-ciscospark/commit/7c13acc))
+* **react-component-spinner:** add bright flag to match new design ([b6c9dc4](https://github.com/ciscospark/react-ciscospark/commit/b6c9dc4))
+* **react-component-title-bar:** add waffle menu ([e5148df](https://github.com/ciscospark/react-ciscospark/commit/e5148df))
+* **react-component-title-bar:** style according to design ([fedb9dc](https://github.com/ciscospark/react-ciscospark/commit/fedb9dc))
+* **react-component-title-bar:** use PresenceAvatar connected component ([3752a76](https://github.com/ciscospark/react-ciscospark/commit/3752a76))
+* **react-component-typing-avatar:** add hover tooltip of name ([bef3ad6](https://github.com/ciscospark/react-ciscospark/commit/bef3ad6))
+* **react-component-typing-avatar:** implement avatar size prop ([e2c82d8](https://github.com/ciscospark/react-ciscospark/commit/e2c82d8))
+* **react-component-typing-avatar:** use PresenceAvatar component ([dc3f893](https://github.com/ciscospark/react-ciscospark/commit/dc3f893))
+* **react-component-utils:** activity constructor requires full conversation object ([748ea19](https://github.com/ciscospark/react-ciscospark/commit/748ea19))
+* **react-component-utils:** add #constructHydraId method ([51e826c](https://github.com/ciscospark/react-ciscospark/commit/51e826c))
+* **react-component-utils:** Add sdk version to metrics ([7b885da](https://github.com/ciscospark/react-ciscospark/commit/7b885da))
+* **react-component-utils:** add validateAndDecodeId function ([e128985](https://github.com/ciscospark/react-ciscospark/commit/e128985))
+* **react-component-utils:** isUuid feature added ([fe9853e](https://github.com/ciscospark/react-ciscospark/commit/fe9853e))
+* **react-component-utils:** store metadata about activity to recreate ([1317c21](https://github.com/ciscospark/react-ciscospark/commit/1317c21))
+* **react-component-video:** change to audio tag if video muted ([5fa0bfe](https://github.com/ciscospark/react-ciscospark/commit/5fa0bfe))
+* **react-container-activity-list:** Add at mention formatter ([34aeec4](https://github.com/ciscospark/react-ciscospark/commit/34aeec4))
+* **react-container-activity-list:** Add at mention formatter and events ([1584f10](https://github.com/ciscospark/react-ciscospark/commit/1584f10))
+* **react-container-activity-list:** add error activities to selector ([a87dcd8](https://github.com/ciscospark/react-ciscospark/commit/a87dcd8))
+* **react-container-activity-list:** Add external formatters ([bf88dce](https://github.com/ciscospark/react-ciscospark/commit/bf88dce))
+* **react-container-activity-list:** remove call data calculation ([06a8d79](https://github.com/ciscospark/react-ciscospark/commit/06a8d79))
+* **react-container-activity-list:** show declined outbound calls as unavailable ([6577a01](https://github.com/ciscospark/react-ciscospark/commit/6577a01))
+* **react-container-activity-list:** support for error activity retries ([4cfa4aa](https://github.com/ciscospark/react-ciscospark/commit/4cfa4aa))
+* **react-container-call-incoming:** create container for handling incoming calls ([1ddaf19](https://github.com/ciscospark/react-ciscospark/commit/1ddaf19))
+* **react-container-call-incoming:** emit event when call is incoming ([461cb24](https://github.com/ciscospark/react-ciscospark/commit/461cb24))
+* **react-container-call-incoming:** implement ringtone component ([6660363](https://github.com/ciscospark/react-ciscospark/commit/6660363))
+* **react-container-call-incoming:** plays ringtone when ringing ([ac58a51](https://github.com/ciscospark/react-ciscospark/commit/ac58a51))
+* **react-container-message-composer:** Add avatar and cleaner styles ([f40a0b7](https://github.com/ciscospark/react-ciscospark/commit/f40a0b7))
+* **react-container-message-composer:** Add debounce to setting UserTyping ([48a7a00](https://github.com/ciscospark/react-ciscospark/commit/48a7a00))
+* **react-container-message-composer:** Add mention support ([5ce172d](https://github.com/ciscospark/react-ciscospark/commit/5ce172d))
+* **react-container-message-composer:** grow text area for longer text inputs ([60b6a79](https://github.com/ciscospark/react-ciscospark/commit/60b6a79))
+* **react-container-message-composer:** use disabled mentions input for text entry ([68b72c1](https://github.com/ciscospark/react-ciscospark/commit/68b72c1))
+* **react-container-notifications:** add incoming call notification ([e6f2ec1](https://github.com/ciscospark/react-ciscospark/commit/e6f2ec1))
+* **react-container-notifications:** Add support to multiple widgets ([f2dfbdd](https://github.com/ciscospark/react-ciscospark/commit/f2dfbdd))
+* **react-container-notifications:** notification generation moved to external component ([a630d3a](https://github.com/ciscospark/react-ciscospark/commit/a630d3a))
+* **react-container-presence-avatar:** initial module ([243da99](https://github.com/ciscospark/react-ciscospark/commit/243da99))
+* **react-container-read-receipts:** add hidden users array ([cc912ae](https://github.com/ciscospark/react-ciscospark/commit/cc912ae))
+* **react-container-read-receipts:** add sort so typing participants get priority ([78c0498](https://github.com/ciscospark/react-ciscospark/commit/78c0498))
+* **react-container-read-receipts:** display count of supressed receipts ([1a26a48](https://github.com/ciscospark/react-ciscospark/commit/1a26a48))
+* **react-container-read-receipts:** fetch avatars for displayed read receipt users ([4746e4e](https://github.com/ciscospark/react-ciscospark/commit/4746e4e))
+* **react-container-read-receipts:** send user id prop ([746ec57](https://github.com/ciscospark/react-ciscospark/commit/746ec57))
+* **react-container-read-receipts:** using selector to create props ([6ed2ba7](https://github.com/ciscospark/react-ciscospark/commit/6ed2ba7))
+* **react-hoc-conversation-mercury:** add initial conversation events ([f38fbc7](https://github.com/ciscospark/react-ciscospark/commit/f38fbc7))
+* **react-hoc-conversation-mercury:** add roster events as comments ([55277f9](https://github.com/ciscospark/react-ciscospark/commit/55277f9))
+* **react-hoc-conversation-mercury:** implement addParticipant/removeParticipant ([5356a4d](https://github.com/ciscospark/react-ciscospark/commit/5356a4d))
+* **react-redux-spark:** Add config options from widget to Spark SDK ([a9d4ba1](https://github.com/ciscospark/react-ciscospark/commit/a9d4ba1))
+* **react-redux-spark:** Add forage storage adapter to cache encryption keys ([92c375f](https://github.com/ciscospark/react-ciscospark/commit/92c375f))
+* **react-redux-spark:** Add longer KMS timeout ([5c4967d](https://github.com/ciscospark/react-ciscospark/commit/5c4967d))
+* **react-redux-spark:** add plugin-people ([20c9b77](https://github.com/ciscospark/react-ciscospark/commit/20c9b77))
+* **react-redux-spark:** Check for global instance before creating new ([2b69a9c](https://github.com/ciscospark/react-ciscospark/commit/2b69a9c))
+* **react-redux-spark:** enable group calling config ([9c54e97](https://github.com/ciscospark/react-ciscospark/commit/9c54e97))
+* **react-redux-spark:** only fire off mercury connect once ([52b75db](https://github.com/ciscospark/react-ciscospark/commit/52b75db))
+* **react-redux-spark:** store registration errors ([989646e](https://github.com/ciscospark/react-ciscospark/commit/989646e))
+* **react-redux-spark-metrics:** Add duration metrics ([a32c9b9](https://github.com/ciscospark/react-ciscospark/commit/a32c9b9))
+* **react-redux-spark-metrics:** Add queuing of metrics ([57eb5d8](https://github.com/ciscospark/react-ciscospark/commit/57eb5d8))
+* **react-redux-spark-metrics:** Clena up actions and add reducers ([1a7116e](https://github.com/ciscospark/react-ciscospark/commit/1a7116e))
+* **react-redux-spark-metrics:** Finished queue and duration send ([783a551](https://github.com/ciscospark/react-ciscospark/commit/783a551))
+* **react-redux-spark-metrics:** Initial metrics framework ([bd3a25b](https://github.com/ciscospark/react-ciscospark/commit/bd3a25b))
+* **react-test-utils:** add shallow render intl helper ([e50729f](https://github.com/ciscospark/react-ciscospark/commit/e50729f))
+* **redux-module-activity:** add ability to retry failed activity ([637715e](https://github.com/ciscospark/react-ciscospark/commit/637715e))
+* **redux-module-activity:** add activity failures to store ([2b5fcf9](https://github.com/ciscospark/react-ciscospark/commit/2b5fcf9))
+* **redux-module-avatar:** add space avatar support ([b32299b](https://github.com/ciscospark/react-ciscospark/commit/b32299b))
+* **redux-module-avatar:** Download smaller avatars for people ([d56b422](https://github.com/ciscospark/react-ciscospark/commit/d56b422))
+* **redux-module-avatar:** handle people api errors ([6f59720](https://github.com/ciscospark/react-ciscospark/commit/6f59720))
+* **redux-module-avatar:** Move all avatar fetching to Promises ([37ff3ea](https://github.com/ciscospark/react-ciscospark/commit/37ff3ea))
+* **redux-module-avatar:** use plugin-people to fetch avatar ([fa94e6c](https://github.com/ciscospark/react-ciscospark/commit/fa94e6c))
+* **redux-module-conversation:** add #removeParticipantFromConversation ([8ef7252](https://github.com/ciscospark/react-ciscospark/commit/8ef7252))
+* **redux-module-conversation:** add ability to add sideboarded participant ([cb78741](https://github.com/ciscospark/react-ciscospark/commit/cb78741))
+* **redux-module-conversation:** add ability to load missing activities ([649ccc0](https://github.com/ciscospark/react-ciscospark/commit/649ccc0))
+* **redux-module-conversation:** add addParticipant action ([c518411](https://github.com/ciscospark/react-ciscospark/commit/c518411))
+* **redux-module-conversation:** add addParticipant and removeParticipant ([d594455](https://github.com/ciscospark/react-ciscospark/commit/d594455))
+* **redux-module-conversation:** add computed room properties ([dc48df3](https://github.com/ciscospark/react-ciscospark/commit/dc48df3))
+* **redux-module-conversation:** add conversation error handling ([2bcd1fd](https://github.com/ciscospark/react-ciscospark/commit/2bcd1fd))
+* **redux-module-conversation:** create participants in flight ([1015796](https://github.com/ciscospark/react-ciscospark/commit/1015796))
+* **redux-module-conversation:** Fix getConversation ([072f5c8](https://github.com/ciscospark/react-ciscospark/commit/072f5c8))
+* **redux-module-conversation:** remove widget message status props ([38d6ad0](https://github.com/ciscospark/react-ciscospark/commit/38d6ad0))
+* **redux-module-errors:** add hasError flag ([53ab035](https://github.com/ciscospark/react-ciscospark/commit/53ab035))
+* **redux-module-errors:** add hasError flag ([5e2bd10](https://github.com/ciscospark/react-ciscospark/commit/5e2bd10))
+* **redux-module-errors:** initial module ([6077d58](https://github.com/ciscospark/react-ciscospark/commit/6077d58))
+* **redux-module-errors:** initial module ([d78087f](https://github.com/ciscospark/react-ciscospark/commit/d78087f))
+* **redux-module-features:** add constants for feature flags ([9661830](https://github.com/ciscospark/react-ciscospark/commit/9661830))
+* **redux-module-features:** initial implementation ([179293f](https://github.com/ciscospark/react-ciscospark/commit/179293f))
+* **redux-module-media:** ability to listen for incoming calls ([06330d4](https://github.com/ciscospark/react-ciscospark/commit/06330d4))
+* **redux-module-media:** add activeParticipantsCount to callState object ([e179878](https://github.com/ciscospark/react-ciscospark/commit/e179878))
+* **redux-module-media:** Add browser support detection ([f2a1951](https://github.com/ciscospark/react-ciscospark/commit/f2a1951))
+* **redux-module-media:** Add disconnect action ([a1dfa79](https://github.com/ciscospark/react-ciscospark/commit/a1dfa79))
+* **redux-module-media:** Add locusUrl to call remove ([34e1b1f](https://github.com/ciscospark/react-ciscospark/commit/34e1b1f))
+* **redux-module-media:** Add passing id for call association ([ef6b867](https://github.com/ciscospark/react-ciscospark/commit/ef6b867))
+* **redux-module-media:** change incoming call handling to new methods ([d92d331](https://github.com/ciscospark/react-ciscospark/commit/d92d331))
+* **redux-module-media:** hang up call on remote decline ([92699e8](https://github.com/ciscospark/react-ciscospark/commit/92699e8))
+* **redux-module-media:** hangup call on disconnect ([aacec65](https://github.com/ciscospark/react-ciscospark/commit/aacec65))
+* **redux-module-media:** make answer incoming call a specific action ([356c75e](https://github.com/ciscospark/react-ciscospark/commit/356c75e))
+* **redux-module-media:** match call via locus url ([f5b2cb9](https://github.com/ciscospark/react-ciscospark/commit/f5b2cb9))
+* **redux-module-media:** remove call.status reference ([bc5406b](https://github.com/ciscospark/react-ciscospark/commit/bc5406b))
+* **redux-module-media:** remove media stream creation ([9be01c1](https://github.com/ciscospark/react-ciscospark/commit/9be01c1))
+* **redux-module-media:** return thunk with call user action ([19b2c7d](https://github.com/ciscospark/react-ciscospark/commit/19b2c7d))
+* **redux-module-media:** store call errors in call state ([32784ac](https://github.com/ciscospark/react-ciscospark/commit/32784ac))
+* **redux-module-media:** update to group supported call events ([0876dc3](https://github.com/ciscospark/react-ciscospark/commit/0876dc3))
+* **redux-module-mercury:** add status object ([7523fc4](https://github.com/ciscospark/react-ciscospark/commit/7523fc4))
+* **redux-module-mercury:** listen to device registration changes ([e6dba57](https://github.com/ciscospark/react-ciscospark/commit/e6dba57))
+* **redux-module-mercury:** listen to device registration changes ([aed4f8b](https://github.com/ciscospark/react-ciscospark/commit/aed4f8b))
+* **redux-module-mercury:** move mercury status out of spark module ([2de0205](https://github.com/ciscospark/react-ciscospark/commit/2de0205))
+* **redux-module-mercury:** Set mercury to connected if already connected from instance ([53f209a](https://github.com/ciscospark/react-ciscospark/commit/53f209a))
+* **redux-module-presence:** initial module ([4f3fcb0](https://github.com/ciscospark/react-ciscospark/commit/4f3fcb0))
+* **redux-module-presence:** use spark presence plugin ([d9dea1a](https://github.com/ciscospark/react-ciscospark/commit/d9dea1a))
+* **redux-module-search:** Add return for results in user search ([efe56b0](https://github.com/ciscospark/react-ciscospark/commit/efe56b0))
+* **redux-module-search:** add search hydra for email ([0f35130](https://github.com/ciscospark/react-ciscospark/commit/0f35130))
+* **redux-module-search:** initial module ([b671b93](https://github.com/ciscospark/react-ciscospark/commit/b671b93))
+* **redux-module-spaces:** Add action to hide space ([991f75d](https://github.com/ciscospark/react-ciscospark/commit/991f75d))
+* **redux-module-spaces:** Add hidden flag and update space storage ([9f29da0](https://github.com/ciscospark/react-ciscospark/commit/9f29da0))
+* **redux-module-spaces:** Add support for defer decryption ([33c0611](https://github.com/ciscospark/react-ciscospark/commit/33c0611))
+* **redux-module-spaces:** filter for latestActivity in #fetchSpace ([3b2fe5e](https://github.com/ciscospark/react-ciscospark/commit/3b2fe5e))
+* **redux-module-spaces:** remove avatar fetch ([c61ae2d](https://github.com/ciscospark/react-ciscospark/commit/c61ae2d))
+* **redux-module-spaces:** Remove teams from module ([ec770f7](https://github.com/ciscospark/react-ciscospark/commit/ec770f7))
+* **redux-module-spaces:** removes ability to fetch direct space avatar ([368f266](https://github.com/ciscospark/react-ciscospark/commit/368f266))
+* **redux-module-spaces:** shorten initial fetch ([1ef1da6](https://github.com/ciscospark/react-ciscospark/commit/1ef1da6))
+* **redux-module-spaces:** Simplify convo retrieval ([dcf9a89](https://github.com/ciscospark/react-ciscospark/commit/dcf9a89))
+* **redux-module-teams:** Add error catch and correct status updates ([8f3a136](https://github.com/ciscospark/react-ciscospark/commit/8f3a136))
+* **redux-module-teams:** Add teams module ([57b1461](https://github.com/ciscospark/react-ciscospark/commit/57b1461))
+* **redux-module-user:** convert request to use people plugin ([3799407](https://github.com/ciscospark/react-ciscospark/commit/3799407))
+* **spark-widget-base:** Add data api and widget removal ([85db05c](https://github.com/ciscospark/react-ciscospark/commit/85db05c))
+* **spark-widget-base:** Create new base widget ([55f7210](https://github.com/ciscospark/react-ciscospark/commit/55f7210))
+* **tooling:** add firefox tests to jenkinsfile ([d5c4c92](https://github.com/ciscospark/react-ciscospark/commit/d5c4c92))
+* **tooling:** Add jest, stylelint and initial circle config ([9e020c7](https://github.com/ciscospark/react-ciscospark/commit/9e020c7))
+* **tooling:** add junit reporting ([126c415](https://github.com/ciscospark/react-ciscospark/commit/126c415))
+* **tooling:** Add npm publish for components ([c2f9369](https://github.com/ciscospark/react-ciscospark/commit/c2f9369))
+* **tooling:** Add public key to repo ([d7dcea1](https://github.com/ciscospark/react-ciscospark/commit/d7dcea1))
+* **tooling:** add sauce job names ([b5eba26](https://github.com/ciscospark/react-ciscospark/commit/b5eba26))
+* **tooling:** Add sri build command ([07d0ed7](https://github.com/ciscospark/react-ciscospark/commit/07d0ed7))
+* **tooling:** Add sri generation and credentials to Jenkinsfile ([733f434](https://github.com/ciscospark/react-ciscospark/commit/733f434))
+* **tooling:** Add SRI generation scripts ([4210488](https://github.com/ciscospark/react-ciscospark/commit/4210488))
+* **tooling:** Add treeshaking ([2a0b5b3](https://github.com/ciscospark/react-ciscospark/commit/2a0b5b3))
+* **tooling:** Added base components with build and dev server ([a1c9faa](https://github.com/ciscospark/react-ciscospark/commit/a1c9faa))
+* **tooling:** Added config to bypass Jest issue with node_modules. ([248e5ba](https://github.com/ciscospark/react-ciscospark/commit/248e5ba))
+* **tooling:** Allow any host connection to local dev ([71b03e9](https://github.com/ciscospark/react-ciscospark/commit/71b03e9))
+* **tooling:** firefox compatibility for journey tests ([7e3f809](https://github.com/ciscospark/react-ciscospark/commit/7e3f809))
+* **tooling:** Fix bad builds, add split package builds ([d652c4c](https://github.com/ciscospark/react-ciscospark/commit/d652c4c))
+* **tooling:** Fix css compile, add file button ([292246e](https://github.com/ciscospark/react-ciscospark/commit/292246e))
+* **tooling:** Remove storybook, add avatar, adjust add file styles ([87b2c01](https://github.com/ciscospark/react-ciscospark/commit/87b2c01))
+* **tooling:** Set version number in webpack build path ([069d9d7](https://github.com/ciscospark/react-ciscospark/commit/069d9d7))
+* **widget:** Add event support for new init methods ([f5cf10b](https://github.com/ciscospark/react-ciscospark/commit/f5cf10b))
+* **widget-base:** Add log level proptypes ([78257c2](https://github.com/ciscospark/react-ciscospark/commit/78257c2))
+* **widget-base:** Add promise and callback to widget.remove() ([200790b](https://github.com/ciscospark/react-ciscospark/commit/200790b))
+* **widget-base:** Add top level allowed props filtering ([199ea9d](https://github.com/ciscospark/react-ciscospark/commit/199ea9d))
+* **widget-base:** Add version to constructor and instance ([43a0448](https://github.com/ciscospark/react-ciscospark/commit/43a0448))
+* **widget-base:** Allow data api to use browser globals if they are available ([b6f0494](https://github.com/ciscospark/react-ciscospark/commit/b6f0494))
+* **widget-base:** Allow for connection in multiple tabs ([dc80faa](https://github.com/ciscospark/react-ciscospark/commit/dc80faa))
+* **widget-base:** Create single constructSparkWidget method ([4c82639](https://github.com/ciscospark/react-ciscospark/commit/4c82639))
+* **widget-base:** update redux devtools implementation ([22f546c](https://github.com/ciscospark/react-ciscospark/commit/22f546c))
+* **widget-example:** Example app that uses new base ([72e2234](https://github.com/ciscospark/react-ciscospark/commit/72e2234))
+* **widget-meet:** accessibility label prop added to call controls ([763b7f9](https://github.com/ciscospark/react-ciscospark/commit/763b7f9))
+* **widget-meet:** accessibility label prop added to call controls ([1c04eef](https://github.com/ciscospark/react-ciscospark/commit/1c04eef))
+* **widget-meet:** Add browser support UI message ([9165fae](https://github.com/ciscospark/react-ciscospark/commit/9165fae))
+* **widget-meet:** Add call controls, 3 views for call state ([6874537](https://github.com/ciscospark/react-ciscospark/commit/6874537))
+* **widget-meet:** Add connect and disconnect button ([9f890d7](https://github.com/ciscospark/react-ciscospark/commit/9f890d7))
+* **widget-meet:** add error when failing to connect call ([c1940db](https://github.com/ciscospark/react-ciscospark/commit/c1940db))
+* **widget-meet:** Add events for call membership changes ([c22bf79](https://github.com/ciscospark/react-ciscospark/commit/c22bf79))
+* **widget-meet:** Add full calling flow scaffolding ([379f77a](https://github.com/ciscospark/react-ciscospark/commit/379f77a))
+* **widget-meet:** Add fuzzy background ([202477d](https://github.com/ciscospark/react-ciscospark/commit/202477d))
+* **widget-meet:** Add incoming and outgoing ringtone ([04f5c82](https://github.com/ciscospark/react-ciscospark/commit/04f5c82))
+* **widget-meet:** Add initial outbound calling ([7400443](https://github.com/ciscospark/react-ciscospark/commit/7400443))
+* **widget-meet:** Add local video draggability ([3c19e2f](https://github.com/ciscospark/react-ciscospark/commit/3c19e2f))
+* **widget-meet:** Add notification events ([3c99eb8](https://github.com/ciscospark/react-ciscospark/commit/3c99eb8))
+* **widget-meet:** Add remote video display ([e957173](https://github.com/ciscospark/react-ciscospark/commit/e957173))
+* **widget-meet:** Add snapping to place to local video drag ([723ff14](https://github.com/ciscospark/react-ciscospark/commit/723ff14))
+* **widget-meet:** Cleanup button styles, add remote audio/video mute ([5da943e](https://github.com/ciscospark/react-ciscospark/commit/5da943e))
+* **widget-meet:** convert container to use selector props ([474bf77](https://github.com/ciscospark/react-ciscospark/commit/474bf77))
+* **widget-meet:** display error for security requirement ([f2b49fc](https://github.com/ciscospark/react-ciscospark/commit/f2b49fc))
+* **widget-meet:** display incoming call screen ([518637d](https://github.com/ciscospark/react-ciscospark/commit/518637d))
+* **widget-meet:** display waiting for participants message ([b49127e](https://github.com/ciscospark/react-ciscospark/commit/b49127e))
+* **widget-meet:** emit event after call user ([d810c09](https://github.com/ciscospark/react-ciscospark/commit/d810c09))
+* **widget-meet:** emit event on call connected ([7822272](https://github.com/ciscospark/react-ciscospark/commit/7822272))
+* **widget-meet:** Fix call state views ([dd8a9ae](https://github.com/ciscospark/react-ciscospark/commit/dd8a9ae))
+* **widget-meet:** handle call state errors ([e3ec5ea](https://github.com/ciscospark/react-ciscospark/commit/e3ec5ea))
+* **widget-meet:** optimize render function with selector ([552fb5a](https://github.com/ciscospark/react-ciscospark/commit/552fb5a))
+* **widget-meet:** Render video srcObject instead of url ([a537aa9](https://github.com/ciscospark/react-ciscospark/commit/a537aa9))
+* **widget-meet:** send locus url to accept incoming call method ([d956f3e](https://github.com/ciscospark/react-ciscospark/commit/d956f3e))
+* **widget-meet:** update call error messages ([ed8533d](https://github.com/ciscospark/react-ciscospark/commit/ed8533d))
+* **widget-meet:** Update call event structure ([2a301f3](https://github.com/ciscospark/react-ciscospark/commit/2a301f3))
+* **widget-meet:** Update styles, move controls into containers ([e57c0b7](https://github.com/ciscospark/react-ciscospark/commit/e57c0b7))
+* **widget-meet:** use #placeCall ([c4c64a7](https://github.com/ciscospark/react-ciscospark/commit/c4c64a7))
+* **widget-message:** add actorName to message event data ([dde2a47](https://github.com/ciscospark/react-ciscospark/commit/dde2a47))
+* **widget-message:** add display of conversation error ([af45cfe](https://github.com/ciscospark/react-ciscospark/commit/af45cfe))
+* **widget-message:** Add feature flag for mentions ([0ca45ba](https://github.com/ciscospark/react-ciscospark/commit/0ca45ba))
+* **widget-message:** add isAcknowledgementsDisabled prop ([76ec124](https://github.com/ciscospark/react-ciscospark/commit/76ec124))
+* **widget-message:** add more detailed activity verb processing ([b751e42](https://github.com/ciscospark/react-ciscospark/commit/b751e42))
+* **widget-message:** Add notification events ([d402aa2](https://github.com/ciscospark/react-ciscospark/commit/d402aa2))
+* **widget-message:** Add roomId to activity event payload ([385bf17](https://github.com/ciscospark/react-ciscospark/commit/385bf17))
+* **widget-message:** enable presence subscription ([79a095f](https://github.com/ciscospark/react-ciscospark/commit/79a095f))
+* **widget-message:** implement activity retry feature ([07760df](https://github.com/ciscospark/react-ciscospark/commit/07760df))
+* **widget-message:** implement buffer state watcher ([57f4585](https://github.com/ciscospark/react-ciscospark/commit/57f4585))
+* **widget-message:** implement hoc-conversation-mercury ([2818a8a](https://github.com/ciscospark/react-ciscospark/commit/2818a8a))
+* **widget-message:** Load conversation before websocket established ([57f9e9d](https://github.com/ciscospark/react-ciscospark/commit/57f9e9d))
+* **widget-message:** mark conversation as read with mouse move ([b32c120](https://github.com/ciscospark/react-ciscospark/commit/b32c120))
+* **widget-message:** Update events model ([a9e85c9](https://github.com/ciscospark/react-ciscospark/commit/a9e85c9))
+* **widget-message:** use feature flag constants ([01eb2b5](https://github.com/ciscospark/react-ciscospark/commit/01eb2b5))
+* **widget-message:** use fetchAvatars method ([14109c2](https://github.com/ciscospark/react-ciscospark/commit/14109c2))
+* **widget-message-meet:** ability to start call via data props ([e21b143](https://github.com/ciscospark/react-ciscospark/commit/e21b143))
+* **widget-message-meet:** Add ability to pass event names ([1ba8342](https://github.com/ciscospark/react-ciscospark/commit/1ba8342))
+* **widget-message-meet:** add accessibility label to main menu ([7d1fc2f](https://github.com/ciscospark/react-ciscospark/commit/7d1fc2f))
+* **widget-message-meet:** add accessibility label to main menu ([3d82113](https://github.com/ciscospark/react-ciscospark/commit/3d82113))
+* **widget-message-meet:** add action for widget menu ([7b7efd7](https://github.com/ciscospark/react-ciscospark/commit/7b7efd7))
+* **widget-message-meet:** Add browser global, additional props ([6e8b718](https://github.com/ciscospark/react-ciscospark/commit/6e8b718))
+* **widget-message-meet:** Add call duration to title bar ([9889b45](https://github.com/ciscospark/react-ciscospark/commit/9889b45))
+* **widget-message-meet:** Add callback and event support ([c980ea3](https://github.com/ciscospark/react-ciscospark/commit/c980ea3))
+* **widget-message-meet:** Add intl support ([759ff03](https://github.com/ciscospark/react-ciscospark/commit/759ff03))
+* **widget-message-meet:** Allow multiple widgets and removal ([ba2878c](https://github.com/ciscospark/react-ciscospark/commit/ba2878c))
+* **widget-message-meet:** do not remove meet widget from dom ([fe2b3e5](https://github.com/ciscospark/react-ciscospark/commit/fe2b3e5))
+* **widget-message-meet:** Go to message view after call ends ([ea36cf4](https://github.com/ciscospark/react-ciscospark/commit/ea36cf4))
+* **widget-message-meet:** hangup active call on unload ([914c80f](https://github.com/ciscospark/react-ciscospark/commit/914c80f))
+* **widget-message-meet:** implement activity menu ([1842c5d](https://github.com/ciscospark/react-ciscospark/commit/1842c5d))
+* **widget-message-meet:** implement initial activity feature ([31486c6](https://github.com/ciscospark/react-ciscospark/commit/31486c6))
+* **widget-message-meet:** in flight message preview ([d08dd8f](https://github.com/ciscospark/react-ciscospark/commit/d08dd8f))
+* **widget-message-meet:** move activity menu from title bar to top ([62b428c](https://github.com/ciscospark/react-ciscospark/commit/62b428c))
+* **widget-message-meet:** Move all widgets to new widget-base ([37e3592](https://github.com/ciscospark/react-ciscospark/commit/37e3592))
+* **widget-message-meet:** properly define imports and exports of widgets ([10ee466](https://github.com/ciscospark/react-ciscospark/commit/10ee466))
+* **widget-message-meet:** properly define imports and exports of widgets ([964a7af](https://github.com/ciscospark/react-ciscospark/commit/964a7af))
+* **widget-message-meet:** toggle between message and meet ([cc8342b](https://github.com/ciscospark/react-ciscospark/commit/cc8342b))
+* **widget-message-meet-demo:** initial implementation ([e38c130](https://github.com/ciscospark/react-ciscospark/commit/e38c130))
+* **widget-recent:** Add incoming call event ([7f5ba02](https://github.com/ciscospark/react-ciscospark/commit/7f5ba02))
+* **widget-recents:** Add ability to load spaces in increments ([af349e0](https://github.com/ciscospark/react-ciscospark/commit/af349e0))
+* **widget-recents:** add accessibility label to call button ([f93d9b6](https://github.com/ciscospark/react-ciscospark/commit/f93d9b6))
+* **widget-recents:** Add activity sender name to preview ([682e6f9](https://github.com/ciscospark/react-ciscospark/commit/682e6f9))
+* **widget-recents:** Add all styles and UI fixes ([f9c439e](https://github.com/ciscospark/react-ciscospark/commit/f9c439e))
+* **widget-recents:** Add direct call button ([b505846](https://github.com/ciscospark/react-ciscospark/commit/b505846))
+* **widget-recents:** add features module ([703e193](https://github.com/ciscospark/react-ciscospark/commit/703e193))
+* **widget-recents:** add fetch space when delete event arrives ([a63db43](https://github.com/ciscospark/react-ciscospark/commit/a63db43))
+* **widget-recents:** Add filter for hidden spaces and move listeners ([84a3796](https://github.com/ciscospark/react-ciscospark/commit/84a3796))
+* **widget-recents:** add group calling feature check ([9f6224d](https://github.com/ciscospark/react-ciscospark/commit/9f6224d))
+* **widget-recents:** Add incoming call view into widgets ([6a81412](https://github.com/ciscospark/react-ciscospark/commit/6a81412))
+* **widget-recents:** Add list constructors ([6d09d5d](https://github.com/ciscospark/react-ciscospark/commit/6d09d5d))
+* **widget-recents:** Add listeners and events for moderation and shares ([5bd448a](https://github.com/ciscospark/react-ciscospark/commit/5bd448a))
+* **widget-recents:** Add listeners for new messages and acknowledges ([b608dc7](https://github.com/ciscospark/react-ciscospark/commit/b608dc7))
+* **widget-recents:** Add membership events ([b12ffbf](https://github.com/ciscospark/react-ciscospark/commit/b12ffbf))
+* **widget-recents:** Add progressive avatar loading ([f1c2e1f](https://github.com/ciscospark/react-ciscospark/commit/f1c2e1f))
+* **widget-recents:** Add rooms:unread and messages:created events ([8f4763b](https://github.com/ciscospark/react-ciscospark/commit/8f4763b))
+* **widget-recents:** Add smaller initial spaces fetch ([0895a1a](https://github.com/ciscospark/react-ciscospark/commit/0895a1a))
+* **widget-recents:** Add spaces fetching ([80b149d](https://github.com/ciscospark/react-ciscospark/commit/80b149d))
+* **widget-recents:** add toPersonEmail to event data ([6ea08ed](https://github.com/ciscospark/react-ciscospark/commit/6ea08ed))
+* **widget-recents:** Add unread indicator ([c0c7880](https://github.com/ciscospark/react-ciscospark/commit/c0c7880))
+* **widget-recents:** Add view for pending space and decrypt support ([775d8bf](https://github.com/ciscospark/react-ciscospark/commit/775d8bf))
+* **widget-recents:** Added initial avatars to direct spaces ([02298da](https://github.com/ciscospark/react-ciscospark/commit/02298da))
+* **widget-recents:** Added non-text messages to list ([ce853cf](https://github.com/ciscospark/react-ciscospark/commit/ce853cf))
+* **widget-recents:** display call button for group spaces ([29503b6](https://github.com/ciscospark/react-ciscospark/commit/29503b6))
+* **widget-recents:** Hide incoming call ui when webrtc is not available ([3a70073](https://github.com/ciscospark/react-ciscospark/commit/3a70073))
+* **widget-recents:** Initial reducers and containers ([07c3959](https://github.com/ciscospark/react-ciscospark/commit/07c3959))
+* **widget-recents:** Progressive fetch rooms if unfetched ([0cffe9e](https://github.com/ciscospark/react-ciscospark/commit/0cffe9e))
+* **widget-recents:** update incoming call listener for group calls ([78c557d](https://github.com/ciscospark/react-ciscospark/commit/78c557d))
+* **widget-recents:** Update to use teams redux module ([0352175](https://github.com/ciscospark/react-ciscospark/commit/0352175))
+* **widget-recents:** use avatar module for direct space avatars ([dc0c13d](https://github.com/ciscospark/react-ciscospark/commit/dc0c13d))
+* **widget-recents:** use avatars module for space avatars ([2c84534](https://github.com/ciscospark/react-ciscospark/commit/2c84534))
+* **widget-recents:** use bright spinner ([c21b20e](https://github.com/ciscospark/react-ciscospark/commit/c21b20e))
+* **widget-recents:** use CallDataActivityMessage in space-item ([ac53694](https://github.com/ciscospark/react-ciscospark/commit/ac53694))
+* **widget-recents:** use space read method ([d249015](https://github.com/ciscospark/react-ciscospark/commit/d249015))
+* **widget-recents:** utilize errors module for display of errors ([c8384af](https://github.com/ciscospark/react-ciscospark/commit/c8384af))
+* **widget-recents-demo:** add aria labels ([729d54d](https://github.com/ciscospark/react-ciscospark/commit/729d54d))
+* **widget-recents-demo:** add support for events array ([a1e976b](https://github.com/ciscospark/react-ciscospark/commit/a1e976b))
+* **widget-recents-demo:** change to basic input ([cf5aaaf](https://github.com/ciscospark/react-ciscospark/commit/cf5aaaf))
+* **widget-recents-demo:** initial implementation ([afafb0e](https://github.com/ciscospark/react-ciscospark/commit/afafb0e))
+* **widget-recents-demo:** use browser global method for widget creation ([b7f8eff](https://github.com/ciscospark/react-ciscospark/commit/b7f8eff))
+* **widget-roster:** Add active call state tracking ([737b613](https://github.com/ciscospark/react-ciscospark/commit/737b613))
+* **widget-roster:** add avatar component to list item ([9077a2d](https://github.com/ciscospark/react-ciscospark/commit/9077a2d))
+* **widget-roster:** add avatar support ([0476511](https://github.com/ciscospark/react-ciscospark/commit/0476511))
+* **widget-roster:** add edit button to roster items ([3bd5cd3](https://github.com/ciscospark/react-ciscospark/commit/3bd5cd3))
+* **widget-roster:** add editingParticipant store data ([833fa2e](https://github.com/ciscospark/react-ciscospark/commit/833fa2e))
+* **widget-roster:** add header bar ([7173b81](https://github.com/ciscospark/react-ciscospark/commit/7173b81))
+* **widget-roster:** add invite email user ([4d11892](https://github.com/ciscospark/react-ciscospark/commit/4d11892))
+* **widget-roster:** add keyboard interaction to add-participant ([81e9a05](https://github.com/ciscospark/react-ciscospark/commit/81e9a05))
+* **widget-roster:** add moderators section to list ([5ee9c2c](https://github.com/ciscospark/react-ciscospark/commit/5ee9c2c))
+* **widget-roster:** add participant details modal ([6cd7132](https://github.com/ciscospark/react-ciscospark/commit/6cd7132))
+* **widget-roster:** add participant settings to redux state ([062f945](https://github.com/ciscospark/react-ciscospark/commit/062f945))
+* **widget-roster:** add PersonListItem display to add participant ([fd7a040](https://github.com/ciscospark/react-ciscospark/commit/fd7a040))
+* **widget-roster:** add roster header component ([3567cdf](https://github.com/ciscospark/react-ciscospark/commit/3567cdf))
+* **widget-roster:** add scroll support for roster list ([af6b927](https://github.com/ciscospark/react-ciscospark/commit/af6b927))
+* **widget-roster:** add search input ([f9c3d30](https://github.com/ciscospark/react-ciscospark/commit/f9c3d30))
+* **widget-roster:** add search module capabilities ([1f577c6](https://github.com/ciscospark/react-ciscospark/commit/1f577c6))
+* **widget-roster:** add user avatars to search results ([6697e9d](https://github.com/ciscospark/react-ciscospark/commit/6697e9d))
+* **widget-roster:** create initial implementation ([58896af](https://github.com/ciscospark/react-ciscospark/commit/58896af))
+* **widget-roster:** display add people button ([c4bf8b7](https://github.com/ciscospark/react-ciscospark/commit/c4bf8b7))
+* **widget-roster:** display external status of users ([fc6cefc](https://github.com/ciscospark/react-ciscospark/commit/fc6cefc))
+* **widget-roster:** display in flight participants ([166a516](https://github.com/ciscospark/react-ciscospark/commit/166a516))
+* **widget-roster:** implement addParticipantToConversation ([f74aed0](https://github.com/ciscospark/react-ciscospark/commit/f74aed0))
+* **widget-roster:** limit consumer org members to email only search ([71edce1](https://github.com/ciscospark/react-ciscospark/commit/71edce1))
+* **widget-roster:** move external message to component ([63ce2f4](https://github.com/ciscospark/react-ciscospark/commit/63ce2f4))
+* **widget-roster:** remove avatar from selector ([4f15360](https://github.com/ciscospark/react-ciscospark/commit/4f15360))
+* **widget-roster:** separate list between current user and others ([4f36a70](https://github.com/ciscospark/react-ciscospark/commit/4f36a70))
+* **widget-roster:** update accessibility label ([ca6176d](https://github.com/ciscospark/react-ciscospark/commit/ca6176d))
+* **widget-roster:** use components to display roster list ([219aa7b](https://github.com/ciscospark/react-ciscospark/commit/219aa7b))
+* **widget-roster:** use react-intl messages for text display ([808eebf](https://github.com/ciscospark/react-ciscospark/commit/808eebf))
+* **widget-space:** add ability to pass props to activities ([915995a](https://github.com/ciscospark/react-ciscospark/commit/915995a))
+* **widget-space:** add ability to update widget status ([17290e5](https://github.com/ciscospark/react-ciscospark/commit/17290e5))
+* **widget-space:** Add Activity Imports for widgets ([bf16319](https://github.com/ciscospark/react-ciscospark/commit/bf16319))
+* **widget-space:** Add activity menu ([6d07c84](https://github.com/ciscospark/react-ciscospark/commit/6d07c84))
+* **widget-space:** Add actorName to calling and rooms events ([d402f82](https://github.com/ciscospark/react-ciscospark/commit/d402f82))
+* **widget-space:** Add call start time ([6adc061](https://github.com/ciscospark/react-ciscospark/commit/6adc061))
+* **widget-space:** add feature ability to activity menu ([96a203f](https://github.com/ciscospark/react-ciscospark/commit/96a203f))
+* **widget-space:** add features module ([771c1d4](https://github.com/ciscospark/react-ciscospark/commit/771c1d4))
+* **widget-space:** add group calling activity menu icon ([43d3e92](https://github.com/ciscospark/react-ciscospark/commit/43d3e92))
+* **widget-space:** add id validation to getSpaceDetails ([981d13b](https://github.com/ciscospark/react-ciscospark/commit/981d13b))
+* **widget-space:** add secondary activity to store ([8e3ded2](https://github.com/ciscospark/react-ciscospark/commit/8e3ded2))
+* **widget-space:** add support for conversation errors ([4a4ff0f](https://github.com/ciscospark/react-ciscospark/commit/4a4ff0f))
+* **widget-space:** add support for feature hide activities ([3f66f78](https://github.com/ciscospark/react-ciscospark/commit/3f66f78))
+* **widget-space:** Add title bar data. Fix eslint errors ([5ab077a](https://github.com/ciscospark/react-ciscospark/commit/5ab077a))
+* **widget-space:** change activity menu to return activity object ([fb4d56a](https://github.com/ciscospark/react-ciscospark/commit/fb4d56a))
+* **widget-space:** change roster feature flag type to developer ([90443e7](https://github.com/ciscospark/react-ciscospark/commit/90443e7))
+* **widget-space:** check error message if error name not matched ([a6dd9ff](https://github.com/ciscospark/react-ciscospark/commit/a6dd9ff))
+* **widget-space:** Create initial container and component ([d84655f](https://github.com/ciscospark/react-ciscospark/commit/d84655f))
+* **widget-space:** display error if to user is self ([7befc72](https://github.com/ciscospark/react-ciscospark/commit/7befc72))
+* **widget-space:** display error on mercury disconnect ([999b2e0](https://github.com/ciscospark/react-ciscospark/commit/999b2e0))
+* **widget-space:** display error on mercury disconnect ([8ba8eb8](https://github.com/ciscospark/react-ciscospark/commit/8ba8eb8))
+* **widget-space:** display secondary widget when chosen ([b22bfbb](https://github.com/ciscospark/react-ciscospark/commit/b22bfbb))
+* **widget-space:** display space errors on load ([27ebf63](https://github.com/ciscospark/react-ciscospark/commit/27ebf63))
+* **widget-space:** Initial frame for widget ([bcce56d](https://github.com/ciscospark/react-ciscospark/commit/bcce56d))
+* **widget-space:** Initial working widgets with message and calling ([d9acb33](https://github.com/ciscospark/react-ciscospark/commit/d9acb33))
+* **widget-space:** move menu button to passed child of title bar ([0873b22](https://github.com/ciscospark/react-ciscospark/commit/0873b22))
+* **widget-space:** remove avatar lookup ([ad18f34](https://github.com/ciscospark/react-ciscospark/commit/ad18f34))
+* **widget-space:** remove call state watcher to switch modes ([d3f138a](https://github.com/ciscospark/react-ciscospark/commit/d3f138a))
+* **widget-space:** Retrieve space details from public api ([4e9ca8e](https://github.com/ciscospark/react-ciscospark/commit/4e9ca8e))
+* **widget-space:** store space details failures ([a52b5f1](https://github.com/ciscospark/react-ciscospark/commit/a52b5f1))
+* **widget-space:** support for error actions ([bcacf75](https://github.com/ciscospark/react-ciscospark/commit/bcacf75))
+* **widget-space:** update space not found message ([d8f2a72](https://github.com/ciscospark/react-ciscospark/commit/d8f2a72))
+* **widget-space:** use errors module to display errors ([0d7806f](https://github.com/ciscospark/react-ciscospark/commit/0d7806f))
+* **widget-space:** use errors module to display errors ([93d8d26](https://github.com/ciscospark/react-ciscospark/commit/93d8d26))
+* **widget-space:** use feature flag constants ([dfc921a](https://github.com/ciscospark/react-ciscospark/commit/dfc921a))
+* **widget-space:** use instanceof for error interpreting ([3709d41](https://github.com/ciscospark/react-ciscospark/commit/3709d41))
+* **widget-space:** widget error object added to selector ([02b29ff](https://github.com/ciscospark/react-ciscospark/commit/02b29ff))
+* **widget-space-demo:** add aria labels to inputs ([6301afd](https://github.com/ciscospark/react-ciscospark/commit/6301afd))
+* **widget-space-demo:** add remove widget button ([df79074](https://github.com/ciscospark/react-ciscospark/commit/df79074))
+* **widget-space-demo:** add support for events array ([da5ef34](https://github.com/ciscospark/react-ciscospark/commit/da5ef34))
+* **widget-space-demo:** add toggle to show token in example code ([c88424e](https://github.com/ciscospark/react-ciscospark/commit/c88424e))
+* **widget-space-demo:** add widget-space to bundle for dev builds ([be95d36](https://github.com/ciscospark/react-ciscospark/commit/be95d36))
+* **widget-space-demo:** change to basic input ([7e61311](https://github.com/ciscospark/react-ciscospark/commit/7e61311))
+* **widget-space-demo:** convert widget creation to global method ([4d5f9d7](https://github.com/ciscospark/react-ciscospark/commit/4d5f9d7))
+* **widget-space-demo:** display global code demo option ([d5ccf11](https://github.com/ciscospark/react-ciscospark/commit/d5ccf11))
+* **widget-space-demo:** initial implementation ([a946852](https://github.com/ciscospark/react-ciscospark/commit/a946852))
+* **widget-space-demo:** revamped look with material cards ([5ae183c](https://github.com/ciscospark/react-ciscospark/commit/5ae183c))
+* **widget-space-demo:** use injected bundle paths ([13e1517](https://github.com/ciscospark/react-ciscospark/commit/13e1517))
+* **wiget-meet:** remove call.joined references ([c6d9f20](https://github.com/ciscospark/react-ciscospark/commit/c6d9f20))
+
+
+### Reverts
+
+* **widget-space:** revert index.html change ([edc403e](https://github.com/ciscospark/react-ciscospark/commit/edc403e))
+
+
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,7 @@ ansiColor('xterm') {
             source ~/.nvm/nvm.sh
             nvm use v8.9.1
             git diff
-            npm version patch -m "build %s"
+            npm run release -- --release-as patch --no-verify
             version=`grep "version" package.json | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g'`
             echo $version > .version
             '''

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CircleCI](https://img.shields.io/circleci/project/github/ciscospark/react-ciscospark/master.svg)](https://circleci.com/gh/ciscospark/react-ciscospark)
 [![license](https://img.shields.io/github/license/ciscospark/react-ciscospark.svg)](https://github.com/ciscospark/react-ciscospark/blob/master/LICENSE)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
 > Cisco Spark for React
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "publish": "cross-env-shell NODE_ENV='' ./scripts/publish/index.js",
     "publish:components": "npm run build:components && npm run build:packagejson && npm run publish components",
     "upgradespark": "./scripts/utils/update.js",
+    "release": "standard-version",
     "precommit": "lint-staged",
     "prepush": "npm run test"
   },
@@ -171,6 +172,7 @@
     "semver": "^5.4.1",
     "sleep-ms": "^2.0.1",
     "sri-toolbox": "^0.2.0",
+    "standard-version": "^4.3.0",
     "style-loader": "^0.19.0",
     "stylelint": "^8.0",
     "stylelint-config-standard": "^17.0",


### PR DESCRIPTION
We'll want to run this with #no-push once Jenkins is working again to make sure everything bumps properly, but it ran fine locally.

Our release commits didn't follow conventional commits, so they don't have proper CHANGELOG entries. (But they will after this)